### PR TITLE
Changing the way we add commands by introducing add(subCommand:)

### DIFF
--- a/Sources/App/main.swift
+++ b/Sources/App/main.swift
@@ -9,15 +9,25 @@
 import Guaka
 
 
+let git = try! Command(
+  name: "git",
+  flags: [
+    Flag(longName: "debug", type: Bool.self, required: true),
+    Flag(longName: "verbose", value: false, shortName: "v", inheritable: true),
+    Flag(longName: "togge", value: false, shortName: "t", inheritable: false),
+    Flag(longName: "root", value: 1, shortName: "r", inheritable: false),
+    ]) { flags, args in
+    print("Running git with \(flags) and \(args)")
+}
+
 let show = try! Command(
   name: "show",
   flags: [
     Flag(longName: "foo", value: "-", inheritable: false),
     Flag(longName: "bar", value: "-", inheritable: false),
     Flag(longName: "yy", value: true, inheritable: false),
-    ],
-  commands: []) { flags, args in
-    print("Running git with \(flags) and \(args)")
+    ]) { flags, args in
+      print("Running git with \(flags) and \(args)")
 }
 
 let remote = try! Command(
@@ -27,31 +37,21 @@ let remote = try! Command(
     Flag(longName: "remote", value: true, inheritable: true),
     Flag(longName: "bar", value: "-", inheritable: false),
     Flag(longName: "xx", value: true, inheritable: false),
-    ],
-  commands: [show]) { flags, args in
-    print("Running git with \(flags) and \(args)")
+    ]) { flags, args in
+      print("Running git with \(flags) and \(args)")
 }
 
 let rebase = try! Command(
   name: "rebase",
   flags: [
     Flag(longName: "varvar", value: false, shortName: "v", inheritable: true),
-    ],
-  commands: []) { flags, args in
-    print("Running git with \(flags) and \(args)")
+    ]) { flags, args in
+      print("Running git with \(flags) and \(args)")
 }
 
-let git = try! Command(
-  name: "git",
-  flags: [
-    Flag(longName: "debug", type: Bool.self, required: true),
-    Flag(longName: "verbose", value: false, shortName: "v", inheritable: true),
-    Flag(longName: "togge", value: false, shortName: "t", inheritable: false),
-    Flag(longName: "root", value: 1, shortName: "r", inheritable: false),
-    ],
-  commands: [rebase, remote]) { flags, args in
-    print("Running git with \(flags) and \(args)")
-}
+git.add(subCommand: remote)
+git.add(subCommand: rebase)
 
+remote.add(subCommand: show)
 
 git.execute(commandLineArgs: CommandLine.arguments)

--- a/Sources/Guaka/Command/Command.swift
+++ b/Sources/Guaka/Command/Command.swift
@@ -14,7 +14,7 @@ public class Command: CommandType {
   public var parent: CommandType?
   public let name: String
   public let flags: [Flag]
-  public let commands: [String: CommandType]
+  public var commands: [String: CommandType] = [:]
   public var run: Run?
   
   public var shortUsage: String?
@@ -22,21 +22,26 @@ public class Command: CommandType {
   
   public init(name: String,
               flags: [Flag],
-              commands: [CommandType] = [],
               shortUsage: String? = nil,
               longUsage: String? = nil,
               run: Run? = nil) throws {
     self.name = name
     self.flags = flags
-    self.commands = try Command.commandsToMap(commands: commands)
     self.run = run
     self.shortUsage = shortUsage
     self.longUsage = longUsage
-    
-    commands.forEach {
-      var mut = $0
-      mut.parent = self
-    }
+  }
+ 
+  public func add(subCommand command: Command) {
+    command.parent = self
+    commands[command.name] = command
   }
   
+  public func add(subCommands commands: Command...) {
+    commands.forEach { add(subCommand: $0) }
+  }
+
+  public func printToConsole(_ string: String) {
+    print(string)
+  }
 }

--- a/Sources/Guaka/CommandType/CommandType+Execution.swift
+++ b/Sources/Guaka/CommandType/CommandType+Execution.swift
@@ -47,13 +47,3 @@ extension CommandType {
   }
   
 }
-
-
-// MARK: Printing
-extension CommandType {
-  
-  public func printToConsole(_ string: String) {
-    print(string)
-  }
-  
-}

--- a/Sources/Guaka/CommandType/CommandType+Help.swift
+++ b/Sources/Guaka/CommandType/CommandType+Help.swift
@@ -39,8 +39,8 @@ extension CommandType {
       return []
     }
     
-    return self.commands.reduce(["Available Commands:"]) { acc, val in
-      let command = val.value
+    let sortedCommands = self.commands.values.sorted { $0.0.name < $0.1.name }
+    return sortedCommands.reduce(["Available Commands:"]) { acc, command in
       return acc + ["  \(command.name)    \(command.shortUsage ?? "")"]
     } + ["\n"]
   }

--- a/Sources/Guaka/CommandType/CommandType.swift
+++ b/Sources/Guaka/CommandType/CommandType.swift
@@ -19,7 +19,7 @@ public protocol CommandType {
   var parent: CommandType? { get set }
   var name: String { get }
   var flags: [Flag] { get }
-  var commands: [String: CommandType] { get }
+  var commands: [String: CommandType] { get set }
   var run: Run? { get set }
   
   var shortUsage: String? { get }
@@ -33,7 +33,6 @@ public protocol CommandType {
   var helpMessage: String { get }
   
   func printToConsole(_ string: String)
-  
 }
 
 
@@ -53,20 +52,6 @@ extension CommandType {
   
   private var inheritableFlags: [Flag] {
     return self.flags.filter { $0.inheritable }
-  }
-  
-  static func commandsToMap(commands: [CommandType]) throws -> [String: CommandType] {
-    var m = [String: CommandType]()
-    
-    try commands.forEach { cmd in
-      if m[cmd.name] == nil {
-        m[cmd.name] = cmd
-      } else {
-        throw CommandErrors.commandAlreadyInserterd(cmd)
-      }
-    }
-    
-    return m
   }
   
 }

--- a/Tests/GuakaTests/CommandExecutionTests.swift
+++ b/Tests/GuakaTests/CommandExecutionTests.swift
@@ -11,43 +11,47 @@ import XCTest
 
 class CommandExecutionTests: XCTestCase {
 
+  override func setUp() {
+    setupTestSamples()
+  }
+  
   func testItCanExecuteShowCommand() {
     //git.execute
     git.execute(commandLineArgs: expand("git remote show --yy"))
     
-    XCTAssertEqual(show.executed?.0.count, 6)
-    XCTAssertEqual(show.executed?.0["yy"]?.value as? Bool, true)
-    XCTAssertEqual(show.executed?.0["debug"]?.value as? Bool, true)
-    XCTAssertEqual(show.executed?.0["verbose"]?.value as? Bool, false)
-    XCTAssertEqual(show.executed?.0["foo"]?.value as? String, "-")
-    XCTAssertEqual(show.executed?.0["remote"]?.value as? Bool, true)
-    XCTAssertEqual(show.executed?.0["bar"]?.value as? String, "-")
+    XCTAssertEqual(executed?.0.count, 6)
+    XCTAssertEqual(executed?.0["yy"]?.value as? Bool, true)
+    XCTAssertEqual(executed?.0["debug"]?.value as? Bool, true)
+    XCTAssertEqual(executed?.0["verbose"]?.value as? Bool, false)
+    XCTAssertEqual(executed?.0["foo"]?.value as? String, "-")
+    XCTAssertEqual(executed?.0["remote"]?.value as? Bool, true)
+    XCTAssertEqual(executed?.0["bar"]?.value as? String, "-")
     
-    XCTAssertEqual((show.executed?.1)!, [])
+    XCTAssertEqual((executed?.1)!, [])
   }
   
   func testItCanExecuteShowCommandWithArgs() {
     //git.execute
     git.execute(commandLineArgs: expand("git remote show --yy aaaa bbbb cccc"))
     
-    XCTAssertEqual(show.executed?.0.count, 6)
+    XCTAssertEqual(executed?.0.count, 6)
     
-    XCTAssertEqual((show.executed?.1)!, ["aaaa", "bbbb", "cccc"])
+    XCTAssertEqual((executed?.1)!, ["aaaa", "bbbb", "cccc"])
   }
   
   func testItCanExecuteRemoteCommand() {
     //git.execute
     git.execute(commandLineArgs: expand("git remote --foo show --xx --bar=123"))
     
-    XCTAssertEqual(remote.executed?.0.count, 6)
-    XCTAssertEqual(remote.executed?.0["xx"]?.value as? Bool, true)
-    XCTAssertEqual(remote.executed?.0["debug"]?.value as? Bool, true)
-    XCTAssertEqual(remote.executed?.0["verbose"]?.value as? Bool, false)
-    XCTAssertEqual(remote.executed?.0["foo"]?.value as? String, "show")
-    XCTAssertEqual(remote.executed?.0["remote"]?.value as? Bool, true)
-    XCTAssertEqual(remote.executed?.0["bar"]?.value as? String, "123")
+    XCTAssertEqual(executed?.0.count, 6)
+    XCTAssertEqual(executed?.0["xx"]?.value as? Bool, true)
+    XCTAssertEqual(executed?.0["debug"]?.value as? Bool, true)
+    XCTAssertEqual(executed?.0["verbose"]?.value as? Bool, false)
+    XCTAssertEqual(executed?.0["foo"]?.value as? String, "show")
+    XCTAssertEqual(executed?.0["remote"]?.value as? Bool, true)
+    XCTAssertEqual(executed?.0["bar"]?.value as? String, "123")
     
-    XCTAssertEqual((remote.executed?.1)!, [])
+    XCTAssertEqual((executed?.1)!, [])
   }
   
   func testItCatchesExceptionsInExecution() {

--- a/Tests/GuakaTests/CommandParsingTests.swift
+++ b/Tests/GuakaTests/CommandParsingTests.swift
@@ -11,6 +11,10 @@ import XCTest
 
 class CommandParsingTests: XCTestCase {
 
+  override func setUp() {
+    setupTestSamples()
+  }
+  
   func testItCanGetACommandWithMultipleArguments() {
     let (command, args) = actualCommand(forCommand: git,
                                         args: ["-vd1", "-v", "--bar", "1", "remote", "--foo", "222", "show"])

--- a/Tests/GuakaTests/CommandTests.swift
+++ b/Tests/GuakaTests/CommandTests.swift
@@ -1,0 +1,24 @@
+//
+//  CommandTests.swift
+//  Guaka
+//
+//  Created by Omar Abdelhafith on 05/11/2016.
+//
+//
+
+import XCTest
+@testable import Guaka
+
+class CommandTests: XCTestCase {
+  
+  override func setUp() {
+    setupTestSamples()
+  }
+  
+  func testItCanAddCommands() {
+    XCTAssertEqual(git.commands.count, 2)
+    git.add(subCommands: show)
+    XCTAssertEqual(git.commands.count, 3)
+  }
+  
+}

--- a/Tests/GuakaTests/CommandTypeTest.swift
+++ b/Tests/GuakaTests/CommandTypeTest.swift
@@ -3,6 +3,10 @@ import XCTest
 
 class CommandTypeTest: XCTestCase {
 
+  override func setUp() {
+    setupTestSamples()
+  }
+  
   func testItCanGenerateFlagSetForRoot() {
     let fs1 = git.flagSet
     XCTAssertEqual(fs1.flags["d"]!.longName, "debug")

--- a/Tests/GuakaTests/ErrorsTests.swift
+++ b/Tests/GuakaTests/ErrorsTests.swift
@@ -11,9 +11,13 @@ import XCTest
 
 class ErrorTests: XCTestCase {
   
+  override func setUp() {
+    setupTestSamples()
+  }
+  
   func testItPrintsFlagNotFoundMessage() {
     let e = CommandErrors.flagNotFound("debug").errorMessage(forCommand: git)
-    XCTAssertEqual(e, "Error: unknown shorthand flag: \'debug\'\nUsage:\n  git [flags]\n  git [command]\n\nAvailable Commands:\n  remote    \n  rebase    \n\nFlags:\n  -d, --debug bool    (default true)\n  -r, --root int      (default 1)\n  -t, --togge bool    (default false)\n  -v, --verbose bool  (default false)\n\nUse \"git [command] --help\" for more information about a command.\n\nunknown shorthand flag: \'debug\'\nexit status 255")
+    XCTAssertEqual(e, "Error: unknown shorthand flag: \'debug\'\nUsage:\n  git [flags]\n  git [command]\n\nAvailable Commands:\n  rebase    \n  remote    \n\nFlags:\n  -d, --debug bool    (default true)\n  -r, --root int      (default 1)\n  -t, --togge bool    (default false)\n  -v, --verbose bool  (default false)\n\nUse \"git [command] --help\" for more information about a command.\n\nunknown shorthand flag: \'debug\'\nexit status 255")
   }
   
   func testItPrintsFlagNotFoundError() {
@@ -23,7 +27,7 @@ class ErrorTests: XCTestCase {
   
   func testItPrintsIncorrectFlagValueFoundErrorMessage() {
     let e = CommandErrors.incorrectFlagValue("debug", "sss", Int.self).errorMessage(forCommand: git)
-    XCTAssertEqual(e, "Error: wrong flag value passed flag: \'debug\' passed value: \'sss\' expected type: \'Int\'\nUsage:\n  git [flags]\n  git [command]\n\nAvailable Commands:\n  remote    \n  rebase    \n\nFlags:\n  -d, --debug bool    (default true)\n  -r, --root int      (default 1)\n  -t, --togge bool    (default false)\n  -v, --verbose bool  (default false)\n\nUse \"git [command] --help\" for more information about a command.\n\nwrong flag value passed flag: \'debug\' passed value: \'sss\' expected type: \'Int\'\nexit status 255")
+    XCTAssertEqual(e, "Error: wrong flag value passed flag: \'debug\' passed value: \'sss\' expected type: \'Int\'\nUsage:\n  git [flags]\n  git [command]\n\nAvailable Commands:\n  rebase    \n  remote    \n\nFlags:\n  -d, --debug bool    (default true)\n  -r, --root int      (default 1)\n  -t, --togge bool    (default false)\n  -v, --verbose bool  (default false)\n\nUse \"git [command] --help\" for more information about a command.\n\nwrong flag value passed flag: \'debug\' passed value: \'sss\' expected type: \'Int\'\nexit status 255")
   }
   
   func testItPrintsIncorrectFlagValueFoundErrorError() {

--- a/Tests/GuakaTests/HelpTests.swift
+++ b/Tests/GuakaTests/HelpTests.swift
@@ -12,6 +12,7 @@ import XCTest
 class HelpTests: XCTestCase {
   
   override func setUp() {
+    setupTestSamples()
     git.shortUsage = nil
     git.longUsage = nil
   }
@@ -24,7 +25,7 @@ class HelpTests: XCTestCase {
   func testItCanGenerateTheCommandsSectionWithoutUsages() {
     show.shortUsage = nil
     show.longUsage = nil
-    XCTAssertEqual(git.avialbleCommandsSection, ["Available Commands:", "  remote    ", "  rebase    ", "\n"])
+    XCTAssertEqual(git.avialbleCommandsSection, ["Available Commands:", "  rebase    ", "  remote    ", "\n"])
     XCTAssertEqual(remote.avialbleCommandsSection, ["Available Commands:", "  show    ", "\n"])
     XCTAssertEqual(show.avialbleCommandsSection, [])
   }
@@ -32,7 +33,7 @@ class HelpTests: XCTestCase {
   func testItCanGenerateTheCommandsSectionWithShortUsages() {
     show.shortUsage = "The short usage"
     show.longUsage = nil
-    XCTAssertEqual(git.avialbleCommandsSection, ["Available Commands:", "  remote    ", "  rebase    ", "\n"])
+    XCTAssertEqual(git.avialbleCommandsSection, ["Available Commands:", "  rebase    ", "  remote    ", "\n"])
     XCTAssertEqual(remote.avialbleCommandsSection, ["Available Commands:", "  show    The short usage", "\n"])
     XCTAssertEqual(show.avialbleCommandsSection, [])
   }
@@ -64,13 +65,14 @@ class HelpTests: XCTestCase {
   
   func testItGenerateTheFullHelp() {
     XCTAssertEqual(git.helpMessage,
-                   "Usage:\n  git [flags]\n  git [command]\n\nAvailable Commands:\n  remote    \n  rebase    \n\nFlags:\n  -d, --debug bool    (default true)\n  -r, --root int      (default 1)\n  -t, --togge bool    (default false)\n  -v, --verbose bool  (default false)\n\nUse \"git [command] --help\" for more information about a command.")
+                   "Usage:\n  git [flags]\n  git [command]\n\nAvailable Commands:\n  rebase    \n  remote    \n\nFlags:\n  -d, --debug bool    (default true)\n  -r, --root int      (default 1)\n  -t, --togge bool    (default false)\n  -v, --verbose bool  (default false)\n\nUse \"git [command] --help\" for more information about a command.")
     
     XCTAssertEqual(remote.helpMessage,
-                   "Usage:\n  remote [flags]\n  remote [command]\n\nAvailable Commands:\n  show    The short usage\n\nFlags:\n      --bar string    (default -)\n  -d, --debug bool    (default true)\n      --foo string    (default -)\n      --remote bool   (default true)\n  -v, --verbose bool  (default false)\n      --xx bool       (default true)\n\nUse \"remote [command] --help\" for more information about a command.")
+                   "Usage:\n  remote [flags]\n  remote [command]\n\nAvailable Commands:\n  show    \n\nFlags:\n      --bar string    (default -)\n  -d, --debug bool    (default true)\n      --foo string    (default -)\n      --remote bool   (default true)\n  -v, --verbose bool  (default false)\n      --xx bool       (default true)\n\nUse \"remote [command] --help\" for more information about a command.")
     
+    show.shortUsage = "Show short usage"
     XCTAssertEqual(show.helpMessage,
-                   "The short usage\n\nUsage:\n  show [flags]\n  show [command]\n\nFlags:\n      --bar string    (default -)\n  -d, --debug bool    (default true)\n      --foo string    (default -)\n      --remote bool   (default true)\n  -v, --verbose bool  (default false)\n      --yy bool       (default true)\n\nUse \"show [command] --help\" for more information about a command.")
+                   "Show short usage\n\nUsage:\n  show [flags]\n  show [command]\n\nFlags:\n      --bar string    (default -)\n  -d, --debug bool    (default true)\n      --foo string    (default -)\n      --remote bool   (default true)\n  -v, --verbose bool  (default false)\n      --yy bool       (default true)\n\nUse \"show [command] --help\" for more information about a command.")
     
     XCTAssertEqual(rebase.helpMessage,
                    "Usage:\n  rebase [flags]\n  rebase [command]\n\nFlags:\n  -d, --debug bool    (default true)\n  -v, --varvar bool   (default false)\n  -v, --verbose bool  (default false)\n\nUse \"rebase [command] --help\" for more information about a command.")

--- a/Tests/GuakaTests/TestHelpers.swift
+++ b/Tests/GuakaTests/TestHelpers.swift
@@ -9,38 +9,21 @@
 import Foundation
 @testable import Guaka
 
-class DummyCommand: CommandType {
-  var parent: CommandType?
-  var name: String
-  var flags: [Flag]
-  var commands: [String: CommandType]
-  var run: CommandType.Run?
-  
-  var shortUsage: String?
-  var longUsage: String?
+class DummyCommand: Command {
   
   var executed: ([String: Flag], [String])?
   var printed: String = ""
   
-  public init(name: String, flags: [Flag], commands: [CommandType] = [],
+  public init(name: String, flags: [Flag],
               parent: Command? = nil, run: CommandType.Run? = nil) throws {
-    self.name = name
-    self.flags = flags
-    self.commands = try Command.commandsToMap(commands: commands)
-    self.parent = parent
-    self.run = run
-    
-    commands.forEach {
-      var mut = $0
-      mut.parent = self
-    }
+    try super.init(name: name, flags: flags, shortUsage: nil, longUsage: nil, run: run)
   }
   
   func execute(flags: [String : Flag], args: [String]) {
     executed = (flags, args)
   }
   
-  func printToConsole(_ string: String) {
+  public override func printToConsole(_ string: String) {
     printed = string
   }
 }
@@ -49,50 +32,66 @@ func expand(_ string: String) -> [String] {
   return string.components(separatedBy: " ")
 }
 
-let show = try! DummyCommand(
-  name: "show",
-  flags: [
-    Flag(longName: "foo", value: "-", inheritable: false),
-    Flag(longName: "bar", value: "-", inheritable: false),
-    Flag(longName: "yy", value: true, inheritable: false),
-    ],
-  commands: [],
-  run: { flags, args in
-    
-})
+var git: DummyCommand!
+var remote: DummyCommand!
+var show: DummyCommand!
+var rebase: DummyCommand!
 
-let remote = try! DummyCommand(
-  name: "remote",
-  flags: [
-    Flag(longName: "foo", value: "-", inheritable: true),
-    Flag(longName: "remote", value: true, inheritable: true),
-    Flag(longName: "bar", value: "-", inheritable: false),
-    Flag(longName: "xx", value: true, inheritable: false),
-    ],
-  commands: [show],
-  run: { flags, args in
-    
-})
+var commandExecuted: DummyCommand? = nil
+var executed: ([String: Flag], [String])? = nil
 
-let rebase = try! DummyCommand(
-  name: "rebase",
-  flags: [
-    Flag(longName: "varvar", value: false, shortName: "v", inheritable: true),
-    ],
-  commands: [],
-  run: { flags, args in
-    
-})
-
-let git = try! DummyCommand(
-  name: "git",
-  flags: [
-    Flag(longName: "debug", value: true, shortName: "d", inheritable: true),
-    Flag(longName: "verbose", value: false, shortName: "v", inheritable: true),
-    Flag(longName: "togge", value: false, shortName: "t", inheritable: false),
-    Flag(longName: "root", value: 1, shortName: "r", inheritable: false),
-    ],
-  commands: [rebase, remote],
-  run: { flags, args in
-    
-})
+func setupTestSamples() {
+  commandExecuted = nil
+  executed = nil
+  
+  show = try! DummyCommand(
+    name: "show",
+    flags: [
+      Flag(longName: "foo", value: "-", inheritable: false),
+      Flag(longName: "bar", value: "-", inheritable: false),
+      Flag(longName: "yy", value: true, inheritable: false),
+      ],
+    run: { flags, args in
+      commandExecuted = show
+      executed = (flags, args)
+  })
+  
+  remote = try! DummyCommand(
+    name: "remote",
+    flags: [
+      Flag(longName: "foo", value: "-", inheritable: true),
+      Flag(longName: "remote", value: true, inheritable: true),
+      Flag(longName: "bar", value: "-", inheritable: false),
+      Flag(longName: "xx", value: true, inheritable: false),
+      ],
+    run: { flags, args in
+      commandExecuted = remote
+      executed = (flags, args)
+  })
+  
+  rebase = try! DummyCommand(
+    name: "rebase",
+    flags: [
+      Flag(longName: "varvar", value: false, shortName: "v", inheritable: true),
+      ],
+    run: { flags, args in
+      commandExecuted = rebase
+      executed = (flags, args)
+  })
+  
+  git = try! DummyCommand(
+    name: "git",
+    flags: [
+      Flag(longName: "debug", value: true, shortName: "d", inheritable: true),
+      Flag(longName: "verbose", value: false, shortName: "v", inheritable: true),
+      Flag(longName: "togge", value: false, shortName: "t", inheritable: false),
+      Flag(longName: "root", value: 1, shortName: "r", inheritable: false),
+      ],
+    run: { flags, args in
+      commandExecuted = git
+      executed = (flags, args)
+  })
+  
+  git.add(subCommands: rebase, remote)
+  remote.add(subCommands: show)
+}


### PR DESCRIPTION
This addresses issue #1 

Now the Command has a method to attach subcommands to it

Questions:
- Do we need remove command?
- Do we need add/remove flags like we did with addcommand?

@goyox86