### PR TITLE
Minor Flags refactoring 

### DIFF
--- a/Sources/Guaka/Command/Command+Utilities.swift
+++ b/Sources/Guaka/Command/Command+Utilities.swift
@@ -1,0 +1,21 @@
+//
+//  Command+Utilities.swift
+//  Guaka
+//
+//  Created by Omar Abdelhafith on 13/11/2016.
+//
+//
+
+import Foundation
+
+extension Command {
+
+  static func name(forUsage usage: String) -> String {
+    if let index = usage.find(string: " ") {
+      return usage[usage.startIndex..<index]
+    } else {
+      return usage
+    }
+  }
+  
+}

--- a/Sources/Guaka/Command/Command.swift
+++ b/Sources/Guaka/Command/Command.swift
@@ -6,14 +6,17 @@
 //
 //
 
-
-public typealias Configuration = (Command) -> ()
+#if os(Linux)
+  @_exported import Glibc
+#else
+  @_exported import Darwin.C
+#endif
 
 
 public class Command: CommandType {
-  
+
   public let name: String
-  public var flags: [Flag]
+
   public var commands: [CommandType] = []
 
   public var inheritablePreRun: ConditionalRun?
@@ -29,40 +32,71 @@ public class Command: CommandType {
 
   public var example: String?
 
+  public var flags: [Flag]
+
+  public var deprecationStatus = DeprecationStatus.notDeprecated
+
   public var parent: CommandType? {
-    didSet {
-      if 
-        let currentParent = self.parent as? Command,
-        let newParent = parent as? Command,
-        newParent !== currentParent  {
-        newParent.add(subCommand: self)
+    willSet {
+      if
+        let oldParent = parent as? Command,
+        let newParent = newValue as? Command,
+        newParent !== oldParent {
+        newParent.add(subCommand: self, setParent: false)
       }
     }
   }
 
-  public var deprecationStatus = DeprecationStatus.notDeprecated
-
+  /// Initialize a command
+  ///
+  /// - parameter name:              Command name
+  /// - parameter shortUsage:        Short usage string
+  /// - parameter longUsage:         Long usage string
+  /// - parameter example:           Example show when printing the help message
+  /// - parameter parent:            The command parent
+  /// - parameter aliases:           List of command aliases
+  /// - parameter deprecationStatus: Command deprecation status
+  /// - parameter flags:             Command list of flags
+  /// - parameter configuration:     Confuguration block to configure the command
+  /// - parameter run:               Callback called when the command is executed
   public init(name: String,
               shortUsage: String? = nil,
               longUsage: String? = nil,
+              example: String? = nil,
               parent: Command? = nil,
+              aliases: [String] = [],
+              deprecationStatus: DeprecationStatus = .notDeprecated,
               flags: [Flag] = [],
               configuration: Configuration? = nil,
               run: Run? = nil) {
     self.name = name
-    self.flags = flags
-    self.run = run
+
     self.shortUsage = shortUsage
     self.longUsage = longUsage
+
+    self.example = example
+    self.deprecationStatus = deprecationStatus
+
+    self.aliases = aliases
+
+    self.flags = flags
+
+    self.run = run
 
     if let parent = parent {
       self.parent = parent
       parent.add(subCommand: self)
     }
-    
+
     configuration?(self)
   }
 
+
+  /// Gets the subcommand with a name
+  ///
+  /// - parameter name: the command name to get
+  ///
+  /// - returns: return a command if found
   public subscript(withName name: String) -> CommandType? {
     for command in commands where
       command.name == name || command.aliases.contains(name) {
@@ -72,29 +106,61 @@ public class Command: CommandType {
     return nil
   }
 
-  public func add(subCommand command: Command) {
-    command.parent = self
-    commands.append(command)
+
+  /// Adds a new subcommand
+  ///
+  /// - parameter command:    the command to add
+  /// - parameter setParent:  set self as parent of the passed command
+  public func add(subCommand command: Command, setParent: Bool = true) {
+    if setParent {
+      command.parent = self
+    }
+
+    if commands.contains(where: { $0.equals(other: command) }) == false {
+      commands.append(command)
+    }
   }
 
+
+  /// Add a list of commands
+  ///
+  /// - parameter commands: the commands to add
   public func add(subCommands commands: Command...) {
     commands.forEach { add(subCommand: $0) }
   }
 
+
+  /// Remove a command
+  ///
+  /// - parameter test: the test to run agains the command
+  /// Returning true from this callback deletes the command
   public func removeCommand(passingTest test: (CommandType) -> Bool) {
     if let index = commands.index(where: { test($0) }) {
       commands.remove(at: index)
     }
   }
 
+
+  /// Adds a flag
+  ///
+  /// - parameter flag: the flag to add
   public func add(flag: Flag) {
     flags.append(flag)
   }
 
+
+  /// Adds a list of flag
+  ///
+  /// - parameter flag: the flags to add
   public func add(flags: [Flag]) {
     self.flags.append(contentsOf: flags)
   }
 
+
+  /// Remove a command
+  ///
+  /// - parameter test: the test to run agains the flag
+  /// Returning true from this callback deletes the flag
   public func removeFlag(passingTest test: (Flag) -> Bool) {
     if let index = flags.index(where: test) {
       flags.remove(at: index)
@@ -103,5 +169,20 @@ public class Command: CommandType {
 
   public func printToConsole(_ string: String) {
     print(string)
+  }
+
+
+  /// Fail, print the help message and exit the application
+  /// Call this method when you want to exit and print the help message
+  ///
+  /// - parameter statusCode: the status code to report
+  public func fail(statusCode: Int) {
+    printToConsole(helpMessage)
+    exit(Int32(statusCode))
+  }
+
+  public func equals(other: CommandType) -> Bool {
+    let command: AnyObject = other as AnyObject
+    return command === self
   }
 }

--- a/Sources/Guaka/Command/Command.swift
+++ b/Sources/Guaka/Command/Command.swift
@@ -15,7 +15,11 @@
 
 public class Command: CommandType {
 
-  public let name: String
+  public var name: String {
+    return Command.name(forUsage: usage)
+  }
+
+  public var usage: String
 
   public var commands: [CommandType] = []
 
@@ -27,8 +31,8 @@ public class Command: CommandType {
 
   public var aliases: [String] = []
 
-  public var shortUsage: String?
-  public var longUsage: String?
+  public var shortMessage: String?
+  public var longMessage: String?
 
   public var example: String?
 
@@ -49,9 +53,9 @@ public class Command: CommandType {
 
   /// Initialize a command
   ///
-  /// - parameter name:              Command name
-  /// - parameter shortUsage:        Short usage string
-  /// - parameter longUsage:         Long usage string
+  /// - parameter usage:             Command usage oneliner
+  /// - parameter shortMessage:      Short usage string
+  /// - parameter longMessage:       Long usage string
   /// - parameter example:           Example show when printing the help message
   /// - parameter parent:            The command parent
   /// - parameter aliases:           List of command aliases
@@ -59,9 +63,9 @@ public class Command: CommandType {
   /// - parameter flags:             Command list of flags
   /// - parameter configuration:     Confuguration block to configure the command
   /// - parameter run:               Callback called when the command is executed
-  public init(name: String,
-              shortUsage: String? = nil,
-              longUsage: String? = nil,
+  public init(usage: String,
+              shortMessage: String? = nil,
+              longMessage: String? = nil,
               example: String? = nil,
               parent: Command? = nil,
               aliases: [String] = [],
@@ -69,10 +73,10 @@ public class Command: CommandType {
               flags: [Flag] = [],
               configuration: Configuration? = nil,
               run: Run? = nil) {
-    self.name = name
+    self.usage = usage
 
-    self.shortUsage = shortUsage
-    self.longUsage = longUsage
+    self.shortMessage = shortMessage
+    self.longMessage = longMessage
 
     self.example = example
     self.deprecationStatus = deprecationStatus

--- a/Sources/Guaka/CommandType/CommandExecution.swift
+++ b/Sources/Guaka/CommandType/CommandExecution.swift
@@ -26,7 +26,7 @@ func executeCommand(rootCommand: CommandType, args: [String]) -> Result {
       throw error
     }
 
-    command.execute(flags: preparedFlags, args: positionalArguments)
+    command.execute(flags: Flags(flags: preparedFlags), args: positionalArguments)
   } catch {
     return .error(CommandErrors.commandGeneralError(command, error))
   }

--- a/Sources/Guaka/CommandType/CommandType+Execution.swift
+++ b/Sources/Guaka/CommandType/CommandType+Execution.swift
@@ -9,8 +9,8 @@
 // MARK: Execution
 extension CommandType {
 
-  public func execute(flags: [String: Flag], args: [String]) {
-    printDeprecationMessages(flags: Array(flags.values))
+  public func execute(flags: Flags, args: [String]) {
+    printDeprecationMessages(flags: Array(flags.flags))
 
     // FIXME: Refactor and simplify
     if

--- a/Sources/Guaka/CommandType/CommandType+Help.swift
+++ b/Sources/Guaka/CommandType/CommandType+Help.swift
@@ -38,22 +38,25 @@ extension CommandType {
       exampleSection.joined(separator: "\n"),
       avialbleCommandsSection.joined(separator: "\n"),
       flagsSection.joined(separator: "\n"),
-      "\n",
       helpSection
       ].joined()
   }
 
   var usageSection: [String] {
-    var usage = [
+    let flagsString = flagSet.flags.count == 0 ? "" : " [flags]"
+
+    let usageParents = path.count == 1 ? "" : path.dropLast().joined(separator: " ") + " "
+
+    var usageString = [
       "Usage:",
-      "  \(name) [flags]"
+      "  \(usageParents)\(usage)\(flagsString)"
     ]
 
     if commands.count > 0 {
-      usage.append("  \(name) [command]")
+      usageString.append("  \(usageParents)\(name) [command]")
     }
     
-    return usage
+    return usageString
   }
 
   var aliasesSection: [String] {
@@ -85,7 +88,7 @@ extension CommandType {
     let sortedCommands = availableCommands.sorted { $0.0.name < $0.1.name }
 
     return sortedCommands.reduce(["Available Commands:"]) { acc, command in
-      return acc + ["  \(command.name)    \(command.shortUsage ?? "")"]
+      return acc + ["  \(command.name)    \(command.shortMessage ?? "")"]
     } + ["\n"]
   }
 
@@ -112,7 +115,7 @@ extension CommandType {
       ret.append("")
     }
 
-    return ret
+    return ret + [""]
   }
 
   var deprecationMessageSection: [String]? {
@@ -123,7 +126,7 @@ extension CommandType {
   }
 
   var commandDescriptionSection: [String] {
-    guard let desc = longUsage ?? shortUsage else { return [] }
+    guard let desc = longMessage ?? shortMessage else { return [] }
     return [desc, "\n\n"]
   }
 

--- a/Sources/Guaka/CommandType/CommandType+Help.swift
+++ b/Sources/Guaka/CommandType/CommandType+Help.swift
@@ -44,11 +44,16 @@ extension CommandType {
   }
 
   var usageSection: [String] {
-    return [
+    var usage = [
       "Usage:",
-      "  \(name) [flags]",
-      "  \(name) [command]"
+      "  \(name) [flags]"
     ]
+
+    if commands.count > 0 {
+      usage.append("  \(name) [command]")
+    }
+    
+    return usage
   }
 
   var aliasesSection: [String] {

--- a/Sources/Guaka/CommandType/CommandType+Utilities.swift
+++ b/Sources/Guaka/CommandType/CommandType+Utilities.swift
@@ -6,8 +6,6 @@
 //
 //
 
-import Foundation
-
 // MARK: Flags
 extension CommandType {
 
@@ -70,21 +68,6 @@ extension CommandType {
     var mut = acc
     mut.append(cmd.name)
     return getPath(cmd: cmd.parent, acc: mut)
-  }
-
-}
-
-
-// MARK: Equality
-extension CommandType {
-
-  // FIXME make sure we test for command childern too
-  func equals(other: Any) -> Bool {
-    guard let other = other as? CommandType else { return false }
-
-    return self.name == other.name &&
-      self.flags == other.flags &&
-      self.commands.count == other.commands.count
   }
 
 }

--- a/Sources/Guaka/CommandType/CommandType.swift
+++ b/Sources/Guaka/CommandType/CommandType.swift
@@ -35,16 +35,19 @@ public typealias Configuration = (Command) -> ()
 
 public protocol CommandType {
 
-  /// The command name
+  /// The command uasage oneliner
+  var usage: String { get }
+
+  /// The command name, this is the first string in the usage
   var name: String { get }
 
   /// The short usages string
   /// This string will be visible when the help of the command is executed
-  var shortUsage: String? { get }
+  var shortMessage: String? { get }
 
   /// The long usages string
   /// This string will be visible when the help of the command is executed
-  var longUsage: String? { get }
+  var longMessage: String? { get }
 
   /// The example section of the command
   /// This will be visible when displaying the command help

--- a/Sources/Guaka/CommandType/CommandType.swift
+++ b/Sources/Guaka/CommandType/CommandType.swift
@@ -13,24 +13,45 @@
 #endif
 
 
+/// Deprecation status type for flags and commands
+///
+/// - notDeprecated: not deprecated, this is the default
+/// - deprecated:    the flag/command is deprecated
 public enum DeprecationStatus {
   case notDeprecated
   case deprecated(String)
 }
 
+/// Run block, called when the command is executed
+public typealias Run = (Flags, [String]) -> ()
 
-public typealias Run = ([String: Flag], [String]) -> ()
-public typealias ConditionalRun = ([String: Flag], [String]) -> (Bool)
+/// Conditional Run block, called when the command is executed
+/// When returining true from this command the execution continues
+/// Returning false, means dont continue the execution
+public typealias ConditionalRun = (Flags, [String]) -> (Bool)
 
+/// Configuration block
+public typealias Configuration = (Command) -> ()
 
 public protocol CommandType {
 
-  /// The parent of this command
-  /// If the command is the root command, the parent will be nil
-  var parent: CommandType? { get }
-
   /// The command name
   var name: String { get }
+
+  /// The short usages string
+  /// This string will be visible when the help of the command is executed
+  var shortUsage: String? { get }
+
+  /// The long usages string
+  /// This string will be visible when the help of the command is executed
+  var longUsage: String? { get }
+
+  /// The example section of the command
+  /// This will be visible when displaying the command help
+  var example: String? { get }
+
+  /// The command deprecation status
+  var deprecationStatus: DeprecationStatus { get set }
 
   /// The flags available for this command
   /// This list contains only the local flags added to the command
@@ -38,6 +59,10 @@ public protocol CommandType {
 
   /// The subcommands this command has
   var commands: [CommandType] { get }
+
+  /// The parent of this command
+  /// If the command is the root command, the parent will be nil
+  var parent: CommandType? { get }
 
   /// After the parsing matches the subcommand, preRun is executed before exacuting run
   /// If preRun returns true, the run is executed next
@@ -69,23 +94,8 @@ public protocol CommandType {
   /// The command will be callable by its name or by any of the aliases set here
   var aliases: [String] { get }
 
-  /// The short usages string
-  /// This string will be visible when the help of the command is executed
-  var shortUsage: String? { get }
-
-  /// The long usages string
-  /// This string will be visible when the help of the command is executed
-  var longUsage: String? { get }
-
-  /// The example section of the command
-  /// This will be visible when displaying the command help
-  var example: String? { get }
-
   /// The console help message for the command
   var helpMessage: String { get }
-
-  /// The command deprecation status
-  var deprecationStatus: DeprecationStatus { get set }
 
   /// Execute this command
   ///
@@ -111,4 +121,7 @@ public protocol CommandType {
   /// Print a string to console
   /// This method is here to simplify command testability
   func printToConsole(_ string: String)
+
+  /// Compare two commands
+  func equals(other: CommandType) -> Bool
 }

--- a/Sources/Guaka/Flag/Flag+Utilities.swift
+++ b/Sources/Guaka/Flag/Flag+Utilities.swift
@@ -1,0 +1,66 @@
+//
+//  Flag+Utilities.swift
+//  Guaka
+//
+//  Created by Omar Abdelhafith on 12/11/2016.
+//
+//
+
+import Foundation
+
+
+extension Flag {
+
+  func convertValueToInnerType(value: String) throws -> CommandStringConvertible {
+
+    do {
+      let v = try self.type.fromString(flagValue: value)
+      return v as! CommandStringConvertible
+    } catch let e as CommandConvertibleError {
+      throw CommandErrors.incorrectFlagValue(self.longName, e.error)
+    }
+
+  }
+
+}
+
+
+extension Flag {
+
+  var flagPrintableName: String {
+    var nameParts: [String] = []
+
+    nameParts.append("  ")
+    if let shortName = shortName {
+      nameParts.append("-\(shortName), ")
+    } else {
+      nameParts.append("    ")
+    }
+
+    nameParts.append("--\(longName)")
+    nameParts.append(" \(self.type.typeDescription)")
+
+    return nameParts.joined()
+  }
+
+  var flagPrintableDescription: String {
+    if description.characters.count == 0 {
+      return self.flagValueDescription
+    }
+
+    return "\(description) \(flagValueDescription)"
+  }
+
+  var flagValueDescription: String {
+    if let value = value {
+      return "(default \(value))"
+    }
+
+    if required {
+      return "(required)"
+    }
+    
+    return ""
+  }
+  
+}

--- a/Sources/Guaka/Flag/Flag.swift
+++ b/Sources/Guaka/Flag/Flag.swift
@@ -6,21 +6,44 @@
 //
 //
 
+
+/// Flag struct
 public struct Flag: Hashable {
 
+  /// Flag long name
   public let longName: String
+
+  /// Flag short name
   public let shortName: String?
+
+  /// Set the flag to be inheritable
+  /// An inheritable flag is valid for a command and all its subcommands
   public let inheritable: Bool
+
+  /// The flag description
   public let description: String
 
+  /// Flag value type
   public let type: CommandStringConvertible.Type
+
+  /// Set the flag to be required
+  // A required flag must be set in order for commands to be executed
   public let required: Bool
 
+  /// Flag value
   public var value: CommandStringConvertible?
-  public var didSet: Bool = false
 
+  /// Flag deprecation status
   public var deprecatedStatus = DeprecationStatus.notDeprecated
 
+
+  /// Creats a new flag
+  ///
+  /// - parameter longName:    Flag long name
+  /// - parameter shortName:   Flag short name
+  /// - parameter value:       Flag default value
+  /// - parameter inheritable: Flag inheritable status
+  /// - parameter description: Flag description to be shown when displaying command help
   public init(longName: String,
               shortName: String? = nil,
               value: CommandStringConvertible,
@@ -36,10 +59,18 @@ public struct Flag: Hashable {
     self.required = true
   }
 
+  /// Creats a new flag
+  ///
+  /// - parameter longName:    Flag long name
+  /// - parameter shortName:   Flag short name
+  /// - parameter type:        Flag value type
+  /// - parameter required:    Flag requirement status
+  /// - parameter inheritable: Flag inheritable status
+  /// - parameter description: Flag description to be shown when displaying command help
   public init(longName: String,
+              shortName: String? = nil,
               type: CommandStringConvertible.Type,
               required: Bool = false,
-              shortName: String? = nil,
               inheritable: Bool = false,
               description: String = "") {
 
@@ -51,72 +82,17 @@ public struct Flag: Hashable {
     self.required = required
   }
 
+  public var hashValue: Int {
+    return longName.hashValue
+  }
 
   var isBool: Bool {
     return value is Bool
   }
 
-  public var hashValue: Int {
-    return longName.hashValue
-  }
+  var didSet: Bool = false
 }
 
 public func ==(left: Flag, right: Flag) -> Bool {
   return left.hashValue == right.hashValue
-}
-
-extension Flag {
-
-  func convertValueToInnerType(value: String) throws -> CommandStringConvertible {
-
-    do {
-      let v = try self.type.fromString(flagValue: value)
-      return v as! CommandStringConvertible
-    } catch let e as CommandConvertibleError {
-      throw CommandErrors.incorrectFlagValue(self.longName, e.error)
-    }
-
-  }
-
-}
-
-
-extension Flag {
-
-  var flagPrintableName: String {
-    var nameParts: [String] = []
-
-    nameParts.append("  ")
-    if let shortName = shortName {
-      nameParts.append("-\(shortName), ")
-    } else {
-      nameParts.append("    ")
-    }
-
-    nameParts.append("--\(longName)")
-    nameParts.append(" \(self.type.typeDescription)")
-
-    return nameParts.joined()
-  }
-
-  var flagPrintableDescription: String {
-    if description.characters.count == 0 {
-      return self.flagValueDescription
-    }
-
-    return "\(description) \(flagValueDescription)"
-  }
-
-  var flagValueDescription: String {
-    if let value = value {
-      return "(default \(value))"
-    }
-
-    if required {
-      return "(required)"
-    }
-
-    return ""
-  }
-
 }

--- a/Sources/Guaka/Flag/Flag.swift
+++ b/Sources/Guaka/Flag/Flag.swift
@@ -82,6 +82,25 @@ public struct Flag: Hashable {
     self.required = required
   }
 
+  /// Creats a switch flag
+  ///
+  /// - parameter longName:    Flag long name
+  /// - parameter shortName:   Flag short name
+  /// - parameter required:    Flag requirement status
+  /// - parameter inheritable: Flag inheritable status
+  /// - parameter description: Flag description to be shown when displaying command help
+  public static func createSwitch(longName: String,
+              shortName: String? = nil,
+              inheritable: Bool = false,
+              description: String = "") -> Flag {
+
+    return Flag(longName: longName,
+                shortName: shortName,
+                value: false,
+                inheritable: inheritable,
+                description: description)
+  }
+
   public var hashValue: Int {
     return longName.hashValue
   }

--- a/Sources/Guaka/Flag/Flags.swift
+++ b/Sources/Guaka/Flag/Flags.swift
@@ -1,0 +1,85 @@
+//
+//  Flag.swift
+//  CommandLine
+//
+//  Created by Omar Abdelhafith on 30/10/2016.
+//
+//
+
+public struct Flags {
+
+  let flagsDict: [String: Flag]
+
+  init(flags: [String: Flag]) {
+    self.flagsDict = flags
+  }
+
+
+  /// All the flags passed
+  public var flags: [Flag] {
+    return Array(flagsDict.values)
+  }
+
+
+  /// Gets a flag with a name
+  ///
+  /// - parameter name: the flag name
+  ///
+  /// - returns: the flag
+  public subscript(name: String) -> Flag? {
+    return flagsDict[name]
+  }
+
+
+  /// Gets a flag with a name
+  ///
+  /// - parameter name: the flag name
+  ///
+  /// - returns: the flag
+  public subscript(valueForName name: String) -> Any? {
+    return flagsDict[name]?.value
+  }
+
+
+
+  /// Gets an integer value for a flag
+  ///
+  /// - parameter name: the flag name
+  ///
+  /// - returns: the value if the flag is found
+  public func getInt(name: String) -> Int? {
+    return flagsDict[name]?.value as? Int
+  }
+
+
+  /// Gets a bool value for a flag
+  ///
+  /// - parameter name: the flag name
+  ///
+  /// - returns: the value if the flag is found
+  public func getBool(name: String) -> Bool? {
+    return flagsDict[name]?.value as? Bool
+  }
+
+
+  /// Gets a string value for a flag
+  ///
+  /// - parameter name: the flag name
+  ///
+  /// - returns: the value if the flag is found
+  public func getString(name: String) -> String? {
+    return flagsDict[name]?.value as? String
+  }
+
+
+  /// Get a value for a type
+  ///
+  /// - parameter name: the flag name
+  /// - parameter type: the type of the flag
+  ///
+  /// - returns: the value if the flag is found
+  public func get<T: CommandStringConvertible>(name: String, type: T.Type) -> T? {
+    return flagsDict[name]?.value as? T
+  }
+
+}

--- a/Tests/GuakaTests/CommandExecutionTests.swift
+++ b/Tests/GuakaTests/CommandExecutionTests.swift
@@ -57,13 +57,13 @@ class CommandExecutionTests: XCTestCase {
   func testItCatchesExceptionsInExecution() {
     //git.execute
     git.execute(commandLineArgs: expand("git remote --foo show --xx --bar=123 --www 123"))
-    XCTAssertEqual(git.printed, "Error: unknown shorthand flag: \'www\'\nUsage:\n  remote [flags]\n  remote [command]\n\nAvailable Commands:\n  show    \n\nFlags:\n      --bar string   (default -)\n      --foo string   (default -)\n      --remote bool  (default true)\n      --xx bool      (default true)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"remote [command] --help\" for more information about a command.\n\nunknown shorthand flag: \'www\'\nexit status 255")
+    XCTAssertEqual(git.printed, "Error: unknown shorthand flag: \'www\'\nUsage:\n  git remote [flags]\n  git remote [command]\n\nAvailable Commands:\n  show    \n\nFlags:\n      --bar string   (default -)\n      --foo string   (default -)\n      --remote bool  (default true)\n      --xx bool      (default true)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"remote [command] --help\" for more information about a command.\n\nunknown shorthand flag: \'www\'\nexit status 255")
   }
 
   func testItCatchesTheHelp() {
     //git.execute
     git.execute(commandLineArgs: expand("git remote --foo show --xx --bar=123 -h"))
-    XCTAssertEqual(git.printed, "Usage:\n  remote [flags]\n  remote [command]\n\nAvailable Commands:\n  show    \n\nFlags:\n      --bar string   (default -)\n      --foo string   (default -)\n      --remote bool  (default true)\n      --xx bool      (default true)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"remote [command] --help\" for more information about a command.")
+    XCTAssertEqual(git.printed, "Usage:\n  git remote [flags]\n  git remote [command]\n\nAvailable Commands:\n  show    \n\nFlags:\n      --bar string   (default -)\n      --foo string   (default -)\n      --remote bool  (default true)\n      --xx bool      (default true)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"remote [command] --help\" for more information about a command.")
   }
 
   func testItCatchesTheCorrectAlias() {

--- a/Tests/GuakaTests/CommandExecutionTests.swift
+++ b/Tests/GuakaTests/CommandExecutionTests.swift
@@ -19,7 +19,7 @@ class CommandExecutionTests: XCTestCase {
     //git.execute
     git.execute(commandLineArgs: expand("git remote show --yy"))
 
-    XCTAssertEqual(executed?.0.count, 6)
+    XCTAssertEqual(executed?.0.flags.count, 6)
     XCTAssertEqual(executed?.0["yy"]?.value as? Bool, true)
     XCTAssertEqual(executed?.0["debug"]?.value as? Bool, true)
     XCTAssertEqual(executed?.0["verbose"]?.value as? Bool, false)
@@ -34,7 +34,7 @@ class CommandExecutionTests: XCTestCase {
     //git.execute
     git.execute(commandLineArgs: expand("git remote show --yy aaaa bbbb cccc"))
 
-    XCTAssertEqual(executed?.0.count, 6)
+    XCTAssertEqual(executed?.0.flags.count, 6)
 
     XCTAssertEqual((executed?.1)!, ["aaaa", "bbbb", "cccc"])
   }
@@ -43,7 +43,7 @@ class CommandExecutionTests: XCTestCase {
     //git.execute
     git.execute(commandLineArgs: expand("git remote --foo show --xx --bar=123"))
 
-    XCTAssertEqual(executed?.0.count, 6)
+    XCTAssertEqual(executed?.0.flags.count, 6)
     XCTAssertEqual(executed?.0["xx"]?.value as? Bool, true)
     XCTAssertEqual(executed?.0["debug"]?.value as? Bool, true)
     XCTAssertEqual(executed?.0["verbose"]?.value as? Bool, false)

--- a/Tests/GuakaTests/CommandParsingTests.swift
+++ b/Tests/GuakaTests/CommandParsingTests.swift
@@ -127,4 +127,13 @@ class CommandParsingTests: XCTestCase {
     XCTAssertEqual(args, ["--yy"])
   }
 
+  func testItCanGetACommandEvenIfUsageIsLong() {
+    show.usage = "show bla bla"
+    let (command, args) = actualCommand(forCommand: git,
+                                        args: ["remote", "show", "--yy"])
+
+    XCTAssertEqual(command.name, "show")
+    XCTAssertEqual(args, ["--yy"])
+  }
+
 }

--- a/Tests/GuakaTests/CommandTests.swift
+++ b/Tests/GuakaTests/CommandTests.swift
@@ -21,6 +21,12 @@ class CommandTests: XCTestCase {
     XCTAssertEqual(git.commands.count, 3)
   }
 
+  func testItCanAddCommandsThroughParent() {
+    XCTAssertEqual(git.commands.count, 2)
+    show.parent = git
+    XCTAssertEqual(git.commands.count, 3)
+  }
+
   func testItCanRemoveACommands() {
     XCTAssertEqual(git.commands.count, 2)
     git.removeCommand { $0.name == "remote" }
@@ -44,5 +50,5 @@ class CommandTests: XCTestCase {
     git.removeFlag { $0.longName == "verbose" }
     XCTAssertEqual(git.flags.count, 3)
   }
-
+  
 }

--- a/Tests/GuakaTests/CommandTests.swift
+++ b/Tests/GuakaTests/CommandTests.swift
@@ -50,5 +50,10 @@ class CommandTests: XCTestCase {
     git.removeFlag { $0.longName == "verbose" }
     XCTAssertEqual(git.flags.count, 3)
   }
+
+  func testItGetsNameForUsage() {
+    XCTAssertEqual(Command.name(forUsage: "git"), "git")
+    XCTAssertEqual(Command.name(forUsage: "show this and that"), "show")
+  }
   
 }

--- a/Tests/GuakaTests/CommandType+Run.swift
+++ b/Tests/GuakaTests/CommandType+Run.swift
@@ -80,7 +80,7 @@ class CommandTypeRunTests: XCTestCase {
     git.inheritablePreRun = { _ in events.append("ipre3"); return true }
 
     let f = show.findAdequateInheritableRun(forPre: true)
-    _ = f?([:], [])
+    _ = f?(Flags(flags: [:]), [])
     XCTAssertEqual(events, ["ipre1"])
   }
 
@@ -92,7 +92,7 @@ class CommandTypeRunTests: XCTestCase {
     git.inheritablePreRun = { _ in events.append("ipre3"); return true }
 
     let f = show.findAdequateInheritableRun(forPre: true)
-    _ = f?([:], [])
+    _ = f?(Flags(flags: [:]), [])
     XCTAssertEqual(events, ["ipre2"])
   }
 
@@ -104,7 +104,7 @@ class CommandTypeRunTests: XCTestCase {
     git.inheritablePreRun = { _ in events.append("ipre3"); return true }
 
     let f = show.findAdequateInheritableRun(forPre: true)
-    _ = f?([:], [])
+    _ = f?(Flags(flags: [:]), [])
     XCTAssertEqual(events, ["ipre3"])
   }
 
@@ -125,7 +125,7 @@ class CommandTypeRunTests: XCTestCase {
     git.inheritablePostRun = { _ in events.append("ipost3"); return true}
 
     let f = show.findAdequateInheritableRun(forPre: false)
-    _ = f?([:], [])
+    _ = f?(Flags(flags: [:]), [])
     XCTAssertEqual(events, ["ipost1"])
   }
 
@@ -137,7 +137,7 @@ class CommandTypeRunTests: XCTestCase {
     git.inheritablePostRun = { _ in events.append("ipost3"); return true}
 
     let f = show.findAdequateInheritableRun(forPre: false)
-    _ = f?([:], [])
+    _ = f?(Flags(flags: [:]), [])
     XCTAssertEqual(events, ["ipost2"])
   }
 
@@ -149,7 +149,7 @@ class CommandTypeRunTests: XCTestCase {
     git.inheritablePostRun = { _ in events.append("ipost3"); return true}
 
     let f = show.findAdequateInheritableRun(forPre: false)
-    _ = f?([:], [])
+    _ = f?(Flags(flags: [:]), [])
     XCTAssertEqual(events, ["ipost3"])
   }
 

--- a/Tests/GuakaTests/FlagsTests.swift
+++ b/Tests/GuakaTests/FlagsTests.swift
@@ -1,0 +1,91 @@
+//
+//  FlagsTests.swift
+//  Guaka
+//
+//  Created by Omar Abdelhafith on 12/11/2016.
+//
+//
+
+import XCTest
+@testable import Guaka
+
+class FlagsTests: XCTestCase {
+
+  func testItReuturnInt() {
+    let flags =
+      ["debug": Flag(longName: "debug", value: true),
+       "bla": Flag(longName: "bla", value: 1)]
+
+    let f = Flags(flags: flags)
+    XCTAssertEqual(f.getInt(name: "bla"), 1)
+  }
+
+  func testItReuturnBool() {
+    let flags =
+      ["debug": Flag(longName: "debug", value: false),
+       "bla": Flag(longName: "bla", value: 1)]
+
+    let f = Flags(flags: flags)
+    XCTAssertEqual(f.getBool(name: "debug"), false)
+  }
+
+  func testItReuturnString() {
+    let flags =
+      ["debug": Flag(longName: "debug", value: "123"),
+       "bla": Flag(longName: "bla", value: 1)]
+
+    let f = Flags(flags: flags)
+    XCTAssertEqual(f.getString(name: "debug"), "123")
+  }
+
+  func testItGetsAFlag() {
+    let flags =
+      ["debug": Flag(longName: "debug", value: "123"),
+       "bla": Flag(longName: "bla", value: 1)]
+
+    let f = Flags(flags: flags)
+    XCTAssertEqual(f["debug"]?.value as? String, "123")
+  }
+
+  func testItGetsAFlagValue() {
+    let flags =
+      ["debug": Flag(longName: "debug", value: "123"),
+       "bla": Flag(longName: "bla", value: 1)]
+
+    let f = Flags(flags: flags)
+    XCTAssertEqual(f[valueForName: "bla"] as? Int, 1)
+  }
+
+  func testItGetsAFlagValueForAType() {
+    let flags =
+      ["debug": Flag(longName: "debug", value: "123"),
+       "bla": Flag(longName: "bla", value: 1)]
+
+    let f = Flags(flags: flags)
+    let v = f.get(name: "debug", type: String.self)
+    XCTAssertEqual(v, "123")
+  }
+
+  func testItHandlesBadFlagNames() {
+    let flags =
+      ["debug": Flag(longName: "debug", value: "123"),
+       "bla": Flag(longName: "bla", value: 1)]
+
+    let f = Flags(flags: flags)
+    let v = f.get(name: "debug222", type: String.self)
+    XCTAssertNil(v)
+  }
+
+  func testItHandlesBadFlagType() {
+    let flags =
+      ["debug": Flag(longName: "debug", value: "123"),
+       "bla": Flag(longName: "bla", value: 1)]
+
+    let f = Flags(flags: flags)
+    let v = f.get(name: "debug", type: Int.self)
+    XCTAssertNil(v)
+    XCTAssertNil(f.getInt(name: "debug"))
+    XCTAssertNil(f.getString(name: "bla"))
+  }
+
+}

--- a/Tests/GuakaTests/HelpTests.swift
+++ b/Tests/GuakaTests/HelpTests.swift
@@ -19,7 +19,7 @@ class HelpTests: XCTestCase {
 
   func testItCanGenerateTheUsageMessage() {
     XCTAssertEqual(git.usageSection, ["Usage:", "  git [flags]", "  git [command]"])
-    XCTAssertEqual(show.usageSection, ["Usage:", "  show [flags]", "  show [command]"])
+    XCTAssertEqual(show.usageSection, ["Usage:", "  show [flags]"])
   }
 
   func testItCanGenerateTheCommandsSectionWithoutUsages() {
@@ -72,10 +72,10 @@ class HelpTests: XCTestCase {
 
     show.shortUsage = "Show short usage"
     XCTAssertEqual(show.helpMessage,
-                   "Show short usage\n\nUsage:\n  show [flags]\n  show [command]\n\nFlags:\n      --bar string  (default -)\n      --foo string  (default -)\n      --yy bool     (default true)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n      --remote bool   (default true)\n  -v, --verbose bool  (default false)\n\nUse \"show [command] --help\" for more information about a command.")
+                   "Show short usage\n\nUsage:\n  show [flags]\n\nFlags:\n      --bar string  (default -)\n      --foo string  (default -)\n      --yy bool     (default true)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n      --remote bool   (default true)\n  -v, --verbose bool  (default false)\n\nUse \"show [command] --help\" for more information about a command.")
 
     XCTAssertEqual(rebase.helpMessage,
-                   "Usage:\n  rebase [flags]\n  rebase [command]\n\nFlags:\n  -v, --varvar bool  (default false)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"rebase [command] --help\" for more information about a command.")
+                   "Usage:\n  rebase [flags]\n\nFlags:\n  -v, --varvar bool  (default false)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"rebase [command] --help\" for more information about a command.")
   }
 
   func testItGenerateTheFullHelpEvenIfRequiredFlagsAreMissing() {
@@ -112,12 +112,12 @@ class HelpTests: XCTestCase {
   func testIfAllFlagsAreDeprecatedItDoesNotShowFlags() {
     rebase.flags[0].deprecatedStatus = .deprecated("Dont use this")
     XCTAssertEqual(rebase.helpMessage,
-                   "Usage:\n  rebase [flags]\n  rebase [command]\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"rebase [command] --help\" for more information about a command.")
+                   "Usage:\n  rebase [flags]\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"rebase [command] --help\" for more information about a command.")
   }
 
   func testItPrintsTheExample() {
     rebase.example = "run git rebase blabla"
     XCTAssertEqual(rebase.helpMessage,
-                   "Usage:\n  rebase [flags]\n  rebase [command]\n\nExamples:\nrun git rebase blabla\n\nFlags:\n  -v, --varvar bool  (default false)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"rebase [command] --help\" for more information about a command.")
+                   "Usage:\n  rebase [flags]\n\nExamples:\nrun git rebase blabla\n\nFlags:\n  -v, --varvar bool  (default false)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"rebase [command] --help\" for more information about a command.")
   }
 }

--- a/Tests/GuakaTests/HelpTests.swift
+++ b/Tests/GuakaTests/HelpTests.swift
@@ -13,26 +13,26 @@ class HelpTests: XCTestCase {
 
   override func setUp() {
     setupTestSamples()
-    git.shortUsage = nil
-    git.longUsage = nil
+    git.shortMessage = nil
+    git.longMessage = nil
   }
 
   func testItCanGenerateTheUsageMessage() {
     XCTAssertEqual(git.usageSection, ["Usage:", "  git [flags]", "  git [command]"])
-    XCTAssertEqual(show.usageSection, ["Usage:", "  show [flags]"])
+    XCTAssertEqual(show.usageSection, ["Usage:", "  git remote show [flags]"])
   }
 
   func testItCanGenerateTheCommandsSectionWithoutUsages() {
-    show.shortUsage = nil
-    show.longUsage = nil
+    show.shortMessage = nil
+    show.longMessage = nil
     XCTAssertEqual(git.avialbleCommandsSection, ["Available Commands:", "  rebase    ", "  remote    ", "\n"])
     XCTAssertEqual(remote.avialbleCommandsSection, ["Available Commands:", "  show    ", "\n"])
     XCTAssertEqual(show.avialbleCommandsSection, [])
   }
 
-  func testItCanGenerateTheCommandsSectionWithShortUsages() {
-    show.shortUsage = "The short usage"
-    show.longUsage = nil
+  func testItCanGenerateTheCommandsSectionWithshortMessages() {
+    show.shortMessage = "The short usage"
+    show.longMessage = nil
     XCTAssertEqual(git.avialbleCommandsSection, ["Available Commands:", "  rebase    ", "  remote    ", "\n"])
     XCTAssertEqual(remote.avialbleCommandsSection, ["Available Commands:", "  show    The short usage", "\n"])
     XCTAssertEqual(show.avialbleCommandsSection, [])
@@ -42,25 +42,25 @@ class HelpTests: XCTestCase {
     XCTAssertEqual(git.commandDescriptionSection, [])
   }
 
-  func testItGenerateTheDescriptionSectionWithShortUsage() {
-    git.shortUsage = "Short git usage"
+  func testItGenerateTheDescriptionSectionWithshortMessage() {
+    git.shortMessage = "Short git usage"
     XCTAssertEqual(git.commandDescriptionSection, ["Short git usage", "\n\n"])
   }
 
-  func testItGenerateTheDescriptionSectionWithLongUsage() {
-    git.longUsage = "Short git usage long"
+  func testItGenerateTheDescriptionSectionWithlongMessage() {
+    git.longMessage = "Short git usage long"
     XCTAssertEqual(git.commandDescriptionSection, ["Short git usage long", "\n\n"])
   }
 
-  func testItGenerateTheDescriptionSectionWithLongAndShortUsage() {
-    git.longUsage = "Short git usage long"
-    git.shortUsage = "Short git usage"
+  func testItGenerateTheDescriptionSectionWithLongAndshortMessage() {
+    git.longMessage = "Short git usage long"
+    git.shortMessage = "Short git usage"
     XCTAssertEqual(git.commandDescriptionSection, ["Short git usage long", "\n\n"])
   }
 
   func testItGenerateTheFlagsSection() {
     XCTAssertEqual(git.flagsSection.joined(separator: "\n"),
-                   "Flags:\n  -d, --debug bool    (default true)\n  -r, --root int      (default 1)\n  -t, --togge bool    (default false)\n  -v, --verbose bool  (default false)\n")
+                   "Flags:\n  -d, --debug bool    (default true)\n  -r, --root int      (default 1)\n  -t, --togge bool    (default false)\n  -v, --verbose bool  (default false)\n\n")
   }
 
   func testItGenerateTheFullHelp() {
@@ -68,14 +68,14 @@ class HelpTests: XCTestCase {
                    "Usage:\n  git [flags]\n  git [command]\n\nAvailable Commands:\n  rebase    \n  remote    \n\nFlags:\n  -d, --debug bool    (default true)\n  -r, --root int      (default 1)\n  -t, --togge bool    (default false)\n  -v, --verbose bool  (default false)\n\nUse \"git [command] --help\" for more information about a command.")
 
     XCTAssertEqual(remote.helpMessage,
-                   "Usage:\n  remote [flags]\n  remote [command]\n\nAvailable Commands:\n  show    \n\nFlags:\n      --bar string   (default -)\n      --foo string   (default -)\n      --remote bool  (default true)\n      --xx bool      (default true)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"remote [command] --help\" for more information about a command.")
+                   "Usage:\n  git remote [flags]\n  git remote [command]\n\nAvailable Commands:\n  show    \n\nFlags:\n      --bar string   (default -)\n      --foo string   (default -)\n      --remote bool  (default true)\n      --xx bool      (default true)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"remote [command] --help\" for more information about a command.")
 
-    show.shortUsage = "Show short usage"
+    show.shortMessage = "Show short usage"
     XCTAssertEqual(show.helpMessage,
-                   "Show short usage\n\nUsage:\n  show [flags]\n\nFlags:\n      --bar string  (default -)\n      --foo string  (default -)\n      --yy bool     (default true)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n      --remote bool   (default true)\n  -v, --verbose bool  (default false)\n\nUse \"show [command] --help\" for more information about a command.")
+                   "Show short usage\n\nUsage:\n  git remote show [flags]\n\nFlags:\n      --bar string  (default -)\n      --foo string  (default -)\n      --yy bool     (default true)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n      --remote bool   (default true)\n  -v, --verbose bool  (default false)\n\nUse \"show [command] --help\" for more information about a command.")
 
     XCTAssertEqual(rebase.helpMessage,
-                   "Usage:\n  rebase [flags]\n\nFlags:\n  -v, --varvar bool  (default false)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"rebase [command] --help\" for more information about a command.")
+                   "Usage:\n  git rebase [flags]\n\nFlags:\n  -v, --varvar bool  (default false)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"rebase [command] --help\" for more information about a command.")
   }
 
   func testItGenerateTheFullHelpEvenIfRequiredFlagsAreMissing() {
@@ -100,24 +100,46 @@ class HelpTests: XCTestCase {
   func testItPrintsCommandDeprecatedOnTopOfDeprecatedCommand() {
     remote.deprecationStatus = .deprecated("Dont use this")
     XCTAssertEqual(remote.helpMessage,
-                   "Command \"remote\" is deprecated, Dont use this\nUsage:\n  remote [flags]\n  remote [command]\n\nAvailable Commands:\n  show    \n\nFlags:\n      --bar string   (default -)\n      --foo string   (default -)\n      --remote bool  (default true)\n      --xx bool      (default true)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"remote [command] --help\" for more information about a command.")
+                   "Command \"remote\" is deprecated, Dont use this\nUsage:\n  git remote [flags]\n  git remote [command]\n\nAvailable Commands:\n  show    \n\nFlags:\n      --bar string   (default -)\n      --foo string   (default -)\n      --remote bool  (default true)\n      --xx bool      (default true)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"remote [command] --help\" for more information about a command.")
   }
 
   func testItFiltersOutDeprecatedFlags() {
     remote.flags[0].deprecatedStatus = .deprecated("Dont use this")
     XCTAssertEqual(remote.helpMessage,
-                   "Usage:\n  remote [flags]\n  remote [command]\n\nAvailable Commands:\n  show    \n\nFlags:\n      --bar string   (default -)\n      --remote bool  (default true)\n      --xx bool      (default true)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"remote [command] --help\" for more information about a command.")
+                   "Usage:\n  git remote [flags]\n  git remote [command]\n\nAvailable Commands:\n  show    \n\nFlags:\n      --bar string   (default -)\n      --remote bool  (default true)\n      --xx bool      (default true)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"remote [command] --help\" for more information about a command.")
   }
 
   func testIfAllFlagsAreDeprecatedItDoesNotShowFlags() {
     rebase.flags[0].deprecatedStatus = .deprecated("Dont use this")
     XCTAssertEqual(rebase.helpMessage,
-                   "Usage:\n  rebase [flags]\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"rebase [command] --help\" for more information about a command.")
+                   "Usage:\n  git rebase [flags]\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"rebase [command] --help\" for more information about a command.")
   }
 
   func testItPrintsTheExample() {
     rebase.example = "run git rebase blabla"
     XCTAssertEqual(rebase.helpMessage,
-                   "Usage:\n  rebase [flags]\n\nExamples:\nrun git rebase blabla\n\nFlags:\n  -v, --varvar bool  (default false)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"rebase [command] --help\" for more information about a command.")
+                   "Usage:\n  git rebase [flags]\n\nExamples:\nrun git rebase blabla\n\nFlags:\n  -v, --varvar bool  (default false)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"rebase [command] --help\" for more information about a command.")
+  }
+
+  func testItPrintsTheUsageSection() {
+    rebase.usage = "rebase bla bla bla"
+    XCTAssertEqual(rebase.name, "rebase")
+    XCTAssertEqual(rebase.helpMessage,
+                   "Usage:\n  git rebase bla bla bla [flags]\n\nFlags:\n  -v, --varvar bool  (default false)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"rebase [command] --help\" for more information about a command.")
+  }
+
+  func testItDoesNotPrintFlagsIfCommandHaveZeroFlags() {
+    git.flags = []
+    git.usage = "git do this"
+    XCTAssertEqual(git.helpMessage,
+                   "Usage:\n  git do this\n  git [command]\n\nAvailable Commands:\n  rebase    \n  remote    \n\nUse \"git [command] --help\" for more information about a command.")
+  }
+
+  func testNoFlagsNoCommands() {
+    git.flags = []
+    git.commands = []
+    git.usage = "git do this"
+    XCTAssertEqual(git.helpMessage,
+                   "Usage:\n  git do this\n\nUse \"git [command] --help\" for more information about a command.")
   }
 }

--- a/Tests/GuakaTests/TestHelpers.swift
+++ b/Tests/GuakaTests/TestHelpers.swift
@@ -16,7 +16,7 @@ class DummyCommand: Command {
 
   public init(name: String, flags: [Flag],
               parent: Command? = nil, run: Run? = nil) throws {
-    super.init(name: name, shortUsage: nil, longUsage: nil, flags: flags, run: run)
+    super.init(usage: name, shortMessage: nil, longMessage: nil, flags: flags, run: run)
   }
 
   func execute(flags: [String : Flag], args: [String]) {

--- a/Tests/GuakaTests/TestHelpers.swift
+++ b/Tests/GuakaTests/TestHelpers.swift
@@ -42,7 +42,7 @@ var show: DummyCommand!
 var rebase: DummyCommand!
 
 var commandExecuted: DummyCommand? = nil
-var executed: ([String: Flag], [String])? = nil
+var executed: (Flags, [String])? = nil
 
 func setupTestSamples() {
   commandExecuted = nil


### PR DESCRIPTION
Added documentation on Flag
Added documentation on Command
Introduced Flags type to encapsulate the flags dictionary

@goyox86 

This improves the flags fetching from this:
```swift
let parent = flags["parent"].value as? String
```

To

```swift
let parent = flags.get(name: "parent", type: String.self)
```