### PR TITLE
Adding usage string

### DIFF
--- a/Sources/Guaka/Command/Command+Utilities.swift
+++ b/Sources/Guaka/Command/Command+Utilities.swift
@@ -1,0 +1,21 @@
+//
+//  Command+Utilities.swift
+//  Guaka
+//
+//  Created by Omar Abdelhafith on 13/11/2016.
+//
+//
+
+import Foundation
+
+extension Command {
+
+  static func name(forUsage usage: String) -> String {
+    if let index = usage.find(string: " ") {
+      return usage[usage.startIndex..<index]
+    } else {
+      return usage
+    }
+  }
+  
+}

--- a/Sources/Guaka/Command/Command.swift
+++ b/Sources/Guaka/Command/Command.swift
@@ -15,7 +15,11 @@
 
 public class Command: CommandType {
 
-  public let name: String
+  public var name: String {
+    return Command.name(forUsage: usage)
+  }
+
+  public var usage: String
 
   public var commands: [CommandType] = []
 
@@ -27,8 +31,8 @@ public class Command: CommandType {
 
   public var aliases: [String] = []
 
-  public var shortUsage: String?
-  public var longUsage: String?
+  public var shortMessage: String?
+  public var longMessage: String?
 
   public var example: String?
 
@@ -49,9 +53,9 @@ public class Command: CommandType {
 
   /// Initialize a command
   ///
-  /// - parameter name:              Command name
-  /// - parameter shortUsage:        Short usage string
-  /// - parameter longUsage:         Long usage string
+  /// - parameter usage:             Command usage oneliner
+  /// - parameter shortMessage:      Short usage string
+  /// - parameter longMessage:       Long usage string
   /// - parameter example:           Example show when printing the help message
   /// - parameter parent:            The command parent
   /// - parameter aliases:           List of command aliases
@@ -59,9 +63,9 @@ public class Command: CommandType {
   /// - parameter flags:             Command list of flags
   /// - parameter configuration:     Confuguration block to configure the command
   /// - parameter run:               Callback called when the command is executed
-  public init(name: String,
-              shortUsage: String? = nil,
-              longUsage: String? = nil,
+  public init(usage: String,
+              shortMessage: String? = nil,
+              longMessage: String? = nil,
               example: String? = nil,
               parent: Command? = nil,
               aliases: [String] = [],
@@ -69,10 +73,10 @@ public class Command: CommandType {
               flags: [Flag] = [],
               configuration: Configuration? = nil,
               run: Run? = nil) {
-    self.name = name
+    self.usage = usage
 
-    self.shortUsage = shortUsage
-    self.longUsage = longUsage
+    self.shortMessage = shortMessage
+    self.longMessage = longMessage
 
     self.example = example
     self.deprecationStatus = deprecationStatus

--- a/Sources/Guaka/CommandType/CommandType+Help.swift
+++ b/Sources/Guaka/CommandType/CommandType+Help.swift
@@ -38,22 +38,23 @@ extension CommandType {
       exampleSection.joined(separator: "\n"),
       avialbleCommandsSection.joined(separator: "\n"),
       flagsSection.joined(separator: "\n"),
-      "\n",
       helpSection
       ].joined()
   }
 
   var usageSection: [String] {
-    var usage = [
+    let flagsString = flagSet.flags.count == 0 ? "" : " [flags]"
+
+    var usageString = [
       "Usage:",
-      "  \(name) [flags]"
+      "  \(usage)\(flagsString)"
     ]
 
     if commands.count > 0 {
-      usage.append("  \(name) [command]")
+      usageString.append("  \(name) [command]")
     }
     
-    return usage
+    return usageString
   }
 
   var aliasesSection: [String] {
@@ -85,7 +86,7 @@ extension CommandType {
     let sortedCommands = availableCommands.sorted { $0.0.name < $0.1.name }
 
     return sortedCommands.reduce(["Available Commands:"]) { acc, command in
-      return acc + ["  \(command.name)    \(command.shortUsage ?? "")"]
+      return acc + ["  \(command.name)    \(command.shortMessage ?? "")"]
     } + ["\n"]
   }
 
@@ -112,7 +113,7 @@ extension CommandType {
       ret.append("")
     }
 
-    return ret
+    return ret + [""]
   }
 
   var deprecationMessageSection: [String]? {
@@ -123,7 +124,7 @@ extension CommandType {
   }
 
   var commandDescriptionSection: [String] {
-    guard let desc = longUsage ?? shortUsage else { return [] }
+    guard let desc = longMessage ?? shortMessage else { return [] }
     return [desc, "\n\n"]
   }
 

--- a/Sources/Guaka/CommandType/CommandType+Help.swift
+++ b/Sources/Guaka/CommandType/CommandType+Help.swift
@@ -45,13 +45,15 @@ extension CommandType {
   var usageSection: [String] {
     let flagsString = flagSet.flags.count == 0 ? "" : " [flags]"
 
+    let usageParents = path.count == 1 ? "" : path.dropLast().joined(separator: " ") + " "
+
     var usageString = [
       "Usage:",
-      "  \(usage)\(flagsString)"
+      "  \(usageParents)\(usage)\(flagsString)"
     ]
 
     if commands.count > 0 {
-      usageString.append("  \(name) [command]")
+      usageString.append("  \(usageParents)\(name) [command]")
     }
     
     return usageString

--- a/Sources/Guaka/CommandType/CommandType.swift
+++ b/Sources/Guaka/CommandType/CommandType.swift
@@ -35,16 +35,19 @@ public typealias Configuration = (Command) -> ()
 
 public protocol CommandType {
 
-  /// The command name
+  /// The command uasage oneliner
+  var usage: String { get }
+
+  /// The command name, this is the first string in the usage
   var name: String { get }
 
   /// The short usages string
   /// This string will be visible when the help of the command is executed
-  var shortUsage: String? { get }
+  var shortMessage: String? { get }
 
   /// The long usages string
   /// This string will be visible when the help of the command is executed
-  var longUsage: String? { get }
+  var longMessage: String? { get }
 
   /// The example section of the command
   /// This will be visible when displaying the command help

--- a/Tests/GuakaTests/CommandExecutionTests.swift
+++ b/Tests/GuakaTests/CommandExecutionTests.swift
@@ -57,13 +57,13 @@ class CommandExecutionTests: XCTestCase {
   func testItCatchesExceptionsInExecution() {
     //git.execute
     git.execute(commandLineArgs: expand("git remote --foo show --xx --bar=123 --www 123"))
-    XCTAssertEqual(git.printed, "Error: unknown shorthand flag: \'www\'\nUsage:\n  remote [flags]\n  remote [command]\n\nAvailable Commands:\n  show    \n\nFlags:\n      --bar string   (default -)\n      --foo string   (default -)\n      --remote bool  (default true)\n      --xx bool      (default true)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"remote [command] --help\" for more information about a command.\n\nunknown shorthand flag: \'www\'\nexit status 255")
+    XCTAssertEqual(git.printed, "Error: unknown shorthand flag: \'www\'\nUsage:\n  git remote [flags]\n  git remote [command]\n\nAvailable Commands:\n  show    \n\nFlags:\n      --bar string   (default -)\n      --foo string   (default -)\n      --remote bool  (default true)\n      --xx bool      (default true)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"remote [command] --help\" for more information about a command.\n\nunknown shorthand flag: \'www\'\nexit status 255")
   }
 
   func testItCatchesTheHelp() {
     //git.execute
     git.execute(commandLineArgs: expand("git remote --foo show --xx --bar=123 -h"))
-    XCTAssertEqual(git.printed, "Usage:\n  remote [flags]\n  remote [command]\n\nAvailable Commands:\n  show    \n\nFlags:\n      --bar string   (default -)\n      --foo string   (default -)\n      --remote bool  (default true)\n      --xx bool      (default true)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"remote [command] --help\" for more information about a command.")
+    XCTAssertEqual(git.printed, "Usage:\n  git remote [flags]\n  git remote [command]\n\nAvailable Commands:\n  show    \n\nFlags:\n      --bar string   (default -)\n      --foo string   (default -)\n      --remote bool  (default true)\n      --xx bool      (default true)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"remote [command] --help\" for more information about a command.")
   }
 
   func testItCatchesTheCorrectAlias() {

--- a/Tests/GuakaTests/CommandParsingTests.swift
+++ b/Tests/GuakaTests/CommandParsingTests.swift
@@ -127,4 +127,13 @@ class CommandParsingTests: XCTestCase {
     XCTAssertEqual(args, ["--yy"])
   }
 
+  func testItCanGetACommandEvenIfUsageIsLong() {
+    show.usage = "show bla bla"
+    let (command, args) = actualCommand(forCommand: git,
+                                        args: ["remote", "show", "--yy"])
+
+    XCTAssertEqual(command.name, "show")
+    XCTAssertEqual(args, ["--yy"])
+  }
+
 }

--- a/Tests/GuakaTests/CommandTests.swift
+++ b/Tests/GuakaTests/CommandTests.swift
@@ -50,5 +50,10 @@ class CommandTests: XCTestCase {
     git.removeFlag { $0.longName == "verbose" }
     XCTAssertEqual(git.flags.count, 3)
   }
+
+  func testItGetsNameForUsage() {
+    XCTAssertEqual(Command.name(forUsage: "git"), "git")
+    XCTAssertEqual(Command.name(forUsage: "show this and that"), "show")
+  }
   
 }

--- a/Tests/GuakaTests/HelpTests.swift
+++ b/Tests/GuakaTests/HelpTests.swift
@@ -13,8 +13,8 @@ class HelpTests: XCTestCase {
 
   override func setUp() {
     setupTestSamples()
-    git.shortUsage = nil
-    git.longUsage = nil
+    git.shortMessage = nil
+    git.longMessage = nil
   }
 
   func testItCanGenerateTheUsageMessage() {
@@ -23,16 +23,16 @@ class HelpTests: XCTestCase {
   }
 
   func testItCanGenerateTheCommandsSectionWithoutUsages() {
-    show.shortUsage = nil
-    show.longUsage = nil
+    show.shortMessage = nil
+    show.longMessage = nil
     XCTAssertEqual(git.avialbleCommandsSection, ["Available Commands:", "  rebase    ", "  remote    ", "\n"])
     XCTAssertEqual(remote.avialbleCommandsSection, ["Available Commands:", "  show    ", "\n"])
     XCTAssertEqual(show.avialbleCommandsSection, [])
   }
 
-  func testItCanGenerateTheCommandsSectionWithShortUsages() {
-    show.shortUsage = "The short usage"
-    show.longUsage = nil
+  func testItCanGenerateTheCommandsSectionWithshortMessages() {
+    show.shortMessage = "The short usage"
+    show.longMessage = nil
     XCTAssertEqual(git.avialbleCommandsSection, ["Available Commands:", "  rebase    ", "  remote    ", "\n"])
     XCTAssertEqual(remote.avialbleCommandsSection, ["Available Commands:", "  show    The short usage", "\n"])
     XCTAssertEqual(show.avialbleCommandsSection, [])
@@ -42,25 +42,25 @@ class HelpTests: XCTestCase {
     XCTAssertEqual(git.commandDescriptionSection, [])
   }
 
-  func testItGenerateTheDescriptionSectionWithShortUsage() {
-    git.shortUsage = "Short git usage"
+  func testItGenerateTheDescriptionSectionWithshortMessage() {
+    git.shortMessage = "Short git usage"
     XCTAssertEqual(git.commandDescriptionSection, ["Short git usage", "\n\n"])
   }
 
-  func testItGenerateTheDescriptionSectionWithLongUsage() {
-    git.longUsage = "Short git usage long"
+  func testItGenerateTheDescriptionSectionWithlongMessage() {
+    git.longMessage = "Short git usage long"
     XCTAssertEqual(git.commandDescriptionSection, ["Short git usage long", "\n\n"])
   }
 
-  func testItGenerateTheDescriptionSectionWithLongAndShortUsage() {
-    git.longUsage = "Short git usage long"
-    git.shortUsage = "Short git usage"
+  func testItGenerateTheDescriptionSectionWithLongAndshortMessage() {
+    git.longMessage = "Short git usage long"
+    git.shortMessage = "Short git usage"
     XCTAssertEqual(git.commandDescriptionSection, ["Short git usage long", "\n\n"])
   }
 
   func testItGenerateTheFlagsSection() {
     XCTAssertEqual(git.flagsSection.joined(separator: "\n"),
-                   "Flags:\n  -d, --debug bool    (default true)\n  -r, --root int      (default 1)\n  -t, --togge bool    (default false)\n  -v, --verbose bool  (default false)\n")
+                   "Flags:\n  -d, --debug bool    (default true)\n  -r, --root int      (default 1)\n  -t, --togge bool    (default false)\n  -v, --verbose bool  (default false)\n\n")
   }
 
   func testItGenerateTheFullHelp() {
@@ -70,7 +70,7 @@ class HelpTests: XCTestCase {
     XCTAssertEqual(remote.helpMessage,
                    "Usage:\n  remote [flags]\n  remote [command]\n\nAvailable Commands:\n  show    \n\nFlags:\n      --bar string   (default -)\n      --foo string   (default -)\n      --remote bool  (default true)\n      --xx bool      (default true)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"remote [command] --help\" for more information about a command.")
 
-    show.shortUsage = "Show short usage"
+    show.shortMessage = "Show short usage"
     XCTAssertEqual(show.helpMessage,
                    "Show short usage\n\nUsage:\n  show [flags]\n\nFlags:\n      --bar string  (default -)\n      --foo string  (default -)\n      --yy bool     (default true)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n      --remote bool   (default true)\n  -v, --verbose bool  (default false)\n\nUse \"show [command] --help\" for more information about a command.")
 
@@ -119,5 +119,27 @@ class HelpTests: XCTestCase {
     rebase.example = "run git rebase blabla"
     XCTAssertEqual(rebase.helpMessage,
                    "Usage:\n  rebase [flags]\n\nExamples:\nrun git rebase blabla\n\nFlags:\n  -v, --varvar bool  (default false)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"rebase [command] --help\" for more information about a command.")
+  }
+
+  func testItPrintsTheUsageSection() {
+    rebase.usage = "rebase bla bla bla"
+    XCTAssertEqual(rebase.name, "rebase")
+    XCTAssertEqual(rebase.helpMessage,
+                   "Usage:\n  rebase bla bla bla [flags]\n\nFlags:\n  -v, --varvar bool  (default false)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"rebase [command] --help\" for more information about a command.")
+  }
+
+  func testItDoesNotPrintFlagsIfCommandHaveZeroFlags() {
+    git.flags = []
+    git.usage = "git do this"
+    XCTAssertEqual(git.helpMessage,
+                   "Usage:\n  git do this\n  git [command]\n\nAvailable Commands:\n  rebase    \n  remote    \n\nUse \"git [command] --help\" for more information about a command.")
+  }
+
+  func testNoFlagsNoCommands() {
+    git.flags = []
+    git.commands = []
+    git.usage = "git do this"
+    XCTAssertEqual(git.helpMessage,
+                   "Usage:\n  git do this\n\nUse \"git [command] --help\" for more information about a command.")
   }
 }

--- a/Tests/GuakaTests/HelpTests.swift
+++ b/Tests/GuakaTests/HelpTests.swift
@@ -19,7 +19,7 @@ class HelpTests: XCTestCase {
 
   func testItCanGenerateTheUsageMessage() {
     XCTAssertEqual(git.usageSection, ["Usage:", "  git [flags]", "  git [command]"])
-    XCTAssertEqual(show.usageSection, ["Usage:", "  show [flags]"])
+    XCTAssertEqual(show.usageSection, ["Usage:", "  git remote show [flags]"])
   }
 
   func testItCanGenerateTheCommandsSectionWithoutUsages() {
@@ -68,14 +68,14 @@ class HelpTests: XCTestCase {
                    "Usage:\n  git [flags]\n  git [command]\n\nAvailable Commands:\n  rebase    \n  remote    \n\nFlags:\n  -d, --debug bool    (default true)\n  -r, --root int      (default 1)\n  -t, --togge bool    (default false)\n  -v, --verbose bool  (default false)\n\nUse \"git [command] --help\" for more information about a command.")
 
     XCTAssertEqual(remote.helpMessage,
-                   "Usage:\n  remote [flags]\n  remote [command]\n\nAvailable Commands:\n  show    \n\nFlags:\n      --bar string   (default -)\n      --foo string   (default -)\n      --remote bool  (default true)\n      --xx bool      (default true)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"remote [command] --help\" for more information about a command.")
+                   "Usage:\n  git remote [flags]\n  git remote [command]\n\nAvailable Commands:\n  show    \n\nFlags:\n      --bar string   (default -)\n      --foo string   (default -)\n      --remote bool  (default true)\n      --xx bool      (default true)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"remote [command] --help\" for more information about a command.")
 
     show.shortMessage = "Show short usage"
     XCTAssertEqual(show.helpMessage,
-                   "Show short usage\n\nUsage:\n  show [flags]\n\nFlags:\n      --bar string  (default -)\n      --foo string  (default -)\n      --yy bool     (default true)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n      --remote bool   (default true)\n  -v, --verbose bool  (default false)\n\nUse \"show [command] --help\" for more information about a command.")
+                   "Show short usage\n\nUsage:\n  git remote show [flags]\n\nFlags:\n      --bar string  (default -)\n      --foo string  (default -)\n      --yy bool     (default true)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n      --remote bool   (default true)\n  -v, --verbose bool  (default false)\n\nUse \"show [command] --help\" for more information about a command.")
 
     XCTAssertEqual(rebase.helpMessage,
-                   "Usage:\n  rebase [flags]\n\nFlags:\n  -v, --varvar bool  (default false)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"rebase [command] --help\" for more information about a command.")
+                   "Usage:\n  git rebase [flags]\n\nFlags:\n  -v, --varvar bool  (default false)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"rebase [command] --help\" for more information about a command.")
   }
 
   func testItGenerateTheFullHelpEvenIfRequiredFlagsAreMissing() {
@@ -100,32 +100,32 @@ class HelpTests: XCTestCase {
   func testItPrintsCommandDeprecatedOnTopOfDeprecatedCommand() {
     remote.deprecationStatus = .deprecated("Dont use this")
     XCTAssertEqual(remote.helpMessage,
-                   "Command \"remote\" is deprecated, Dont use this\nUsage:\n  remote [flags]\n  remote [command]\n\nAvailable Commands:\n  show    \n\nFlags:\n      --bar string   (default -)\n      --foo string   (default -)\n      --remote bool  (default true)\n      --xx bool      (default true)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"remote [command] --help\" for more information about a command.")
+                   "Command \"remote\" is deprecated, Dont use this\nUsage:\n  git remote [flags]\n  git remote [command]\n\nAvailable Commands:\n  show    \n\nFlags:\n      --bar string   (default -)\n      --foo string   (default -)\n      --remote bool  (default true)\n      --xx bool      (default true)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"remote [command] --help\" for more information about a command.")
   }
 
   func testItFiltersOutDeprecatedFlags() {
     remote.flags[0].deprecatedStatus = .deprecated("Dont use this")
     XCTAssertEqual(remote.helpMessage,
-                   "Usage:\n  remote [flags]\n  remote [command]\n\nAvailable Commands:\n  show    \n\nFlags:\n      --bar string   (default -)\n      --remote bool  (default true)\n      --xx bool      (default true)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"remote [command] --help\" for more information about a command.")
+                   "Usage:\n  git remote [flags]\n  git remote [command]\n\nAvailable Commands:\n  show    \n\nFlags:\n      --bar string   (default -)\n      --remote bool  (default true)\n      --xx bool      (default true)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"remote [command] --help\" for more information about a command.")
   }
 
   func testIfAllFlagsAreDeprecatedItDoesNotShowFlags() {
     rebase.flags[0].deprecatedStatus = .deprecated("Dont use this")
     XCTAssertEqual(rebase.helpMessage,
-                   "Usage:\n  rebase [flags]\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"rebase [command] --help\" for more information about a command.")
+                   "Usage:\n  git rebase [flags]\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"rebase [command] --help\" for more information about a command.")
   }
 
   func testItPrintsTheExample() {
     rebase.example = "run git rebase blabla"
     XCTAssertEqual(rebase.helpMessage,
-                   "Usage:\n  rebase [flags]\n\nExamples:\nrun git rebase blabla\n\nFlags:\n  -v, --varvar bool  (default false)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"rebase [command] --help\" for more information about a command.")
+                   "Usage:\n  git rebase [flags]\n\nExamples:\nrun git rebase blabla\n\nFlags:\n  -v, --varvar bool  (default false)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"rebase [command] --help\" for more information about a command.")
   }
 
   func testItPrintsTheUsageSection() {
     rebase.usage = "rebase bla bla bla"
     XCTAssertEqual(rebase.name, "rebase")
     XCTAssertEqual(rebase.helpMessage,
-                   "Usage:\n  rebase bla bla bla [flags]\n\nFlags:\n  -v, --varvar bool  (default false)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"rebase [command] --help\" for more information about a command.")
+                   "Usage:\n  git rebase bla bla bla [flags]\n\nFlags:\n  -v, --varvar bool  (default false)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"rebase [command] --help\" for more information about a command.")
   }
 
   func testItDoesNotPrintFlagsIfCommandHaveZeroFlags() {

--- a/Tests/GuakaTests/TestHelpers.swift
+++ b/Tests/GuakaTests/TestHelpers.swift
@@ -16,7 +16,7 @@ class DummyCommand: Command {
 
   public init(name: String, flags: [Flag],
               parent: Command? = nil, run: Run? = nil) throws {
-    super.init(name: name, shortUsage: nil, longUsage: nil, flags: flags, run: run)
+    super.init(usage: name, shortMessage: nil, longMessage: nil, flags: flags, run: run)
   }
 
   func execute(flags: [String : Flag], args: [String]) {


### PR DESCRIPTION
Adding usage string.

Now the command will set the usage when calling `helpMessage`
The name of the command will be the first string in the usage

For example, for usage `show origin-name`
The command name is `show`

When displaying the help we will have:

```
Usage:
  git remote show origin-name
```

@goyox86 