### PR TITLE
Removing description strings from boolean flags

### DIFF
--- a/Sources/Guaka/CommandType/CommandExecution.swift
+++ b/Sources/Guaka/CommandType/CommandExecution.swift
@@ -6,7 +6,7 @@ func executeCommand(rootCommand: CommandType, args: [String]) -> Result {
   let (command, args) = actualCommand(forCommand: rootCommand, args: args)
   let flagSet = command.flagSet
 
-  let flagSetWithHelp = flagSet.flagSetAppeningHelp()
+  let flagSetWithHelp = flagSet.flagSetAppendingHelp()
 
   do {
     let (optionFlags, positionalArguments) = try flagSetWithHelp.parse(args: args)

--- a/Sources/Guaka/CommandType/CommandType+Help.swift
+++ b/Sources/Guaka/CommandType/CommandType+Help.swift
@@ -100,7 +100,8 @@ extension CommandType {
 
     var ret: [String] = []
 
-    let localFlagsDescription = fs.localDescription(withLocalFlags: flags)
+    let localFlagsDescription = fs.localFlagDescription(withLocalFlags: flags)
+
     if localFlagsDescription != "" {
       ret.append("Flags:")
       ret.append(localFlagsDescription)
@@ -108,7 +109,7 @@ extension CommandType {
     }
 
 
-    let globalFlagsDescription = fs.globalDescription(withLocalFlags: flags)
+    let globalFlagsDescription = fs.globalFlagsDescription(withLocalFlags: flags)
     if globalFlagsDescription != "" {
       ret.append("Global Flags:")
       ret.append(globalFlagsDescription)

--- a/Sources/Guaka/Flag/Flag+Utilities.swift
+++ b/Sources/Guaka/Flag/Flag+Utilities.swift
@@ -52,6 +52,8 @@ extension Flag {
   }
 
   var flagValueDescription: String {
+    if isBool { return "" }
+    
     if let value = value {
       return "(default \(value))"
     }

--- a/Sources/Guaka/Types/CommandStringConvertible.swift
+++ b/Sources/Guaka/Types/CommandStringConvertible.swift
@@ -36,7 +36,7 @@ extension Bool: CommandStringConvertible {
     throw CommandConvertibleError.conversionError("cannot convert '\(value)' to '\(Bool.self)' ")
   }
 
-  public static var typeDescription: String { return "bool" }
+  public static var typeDescription: String { return "" }
 
 }
 

--- a/Tests/GuakaTests/CommandExecutionTests.swift
+++ b/Tests/GuakaTests/CommandExecutionTests.swift
@@ -57,13 +57,13 @@ class CommandExecutionTests: XCTestCase {
   func testItCatchesExceptionsInExecution() {
     //git.execute
     git.execute(commandLineArgs: expand("git remote --foo show --xx --bar=123 --www 123"))
-    XCTAssertEqual(git.printed, "Error: unknown shorthand flag: \'www\'\nUsage:\n  git remote [flags]\n  git remote [command]\n\nAvailable Commands:\n  show    \n\nFlags:\n      --bar string   (default -)\n      --foo string   (default -)\n      --remote bool  (default true)\n      --xx bool      (default true)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"remote [command] --help\" for more information about a command.\n\nunknown shorthand flag: \'www\'\nexit status 255")
+    XCTAssertEqual(git.printed, "Error: unknown shorthand flag: \'www\'\nUsage:\n  git remote [flags]\n  git remote [command]\n\nAvailable Commands:\n  show    \n\nFlags:\n      --bar string  (default -)\n      --foo string  (default -)\n      --remote      \n      --xx          \n\nGlobal Flags:\n  -d, --debug     \n  -v, --verbose   \n\nUse \"remote [command] --help\" for more information about a command.\n\nunknown shorthand flag: \'www\'\nexit status 255")
   }
 
   func testItCatchesTheHelp() {
     //git.execute
     git.execute(commandLineArgs: expand("git remote --foo show --xx --bar=123 -h"))
-    XCTAssertEqual(git.printed, "Usage:\n  git remote [flags]\n  git remote [command]\n\nAvailable Commands:\n  show    \n\nFlags:\n      --bar string   (default -)\n      --foo string   (default -)\n      --remote bool  (default true)\n      --xx bool      (default true)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"remote [command] --help\" for more information about a command.")
+    XCTAssertEqual(git.printed, "Usage:\n  git remote [flags]\n  git remote [command]\n\nAvailable Commands:\n  show    \n\nFlags:\n      --bar string  (default -)\n      --foo string  (default -)\n      --remote      \n      --xx          \n\nGlobal Flags:\n  -d, --debug     \n  -v, --verbose   \n\nUse \"remote [command] --help\" for more information about a command.")
   }
 
   func testItCatchesTheCorrectAlias() {
@@ -121,7 +121,7 @@ class CommandExecutionTests: XCTestCase {
     //git.execute
     git.add(flag: Flag(longName: "req", type: String.self, required: true))
     git.execute(commandLineArgs: expand("git"))
-    XCTAssertEqual(git.printed, "Error: required flag was not set: \'req\' expected type: \'String\'\nUsage:\n  git [flags]\n  git [command]\n\nAvailable Commands:\n  rebase    \n  remote    \n\nFlags:\n  -d, --debug bool    (default true)\n      --req string    (required)\n  -r, --root int      (default 1)\n  -t, --togge bool    (default false)\n  -v, --verbose bool  (default false)\n\nUse \"git [command] --help\" for more information about a command.\n\nrequired flag was not set: \'req\' expected type: \'String\'\nexit status 255")
+    XCTAssertEqual(git.printed, "Error: required flag was not set: \'req\' expected type: \'String\'\nUsage:\n  git [flags]\n  git [command]\n\nAvailable Commands:\n  rebase    \n  remote    \n\nFlags:\n  -d, --debug       \n      --req string  (required)\n  -r, --root int    (default 1)\n  -t, --togge       \n  -v, --verbose     \n\nUse \"git [command] --help\" for more information about a command.\n\nrequired flag was not set: \'req\' expected type: \'String\'\nexit status 255")
   }
 }
 

--- a/Tests/GuakaTests/ErrorsTests.swift
+++ b/Tests/GuakaTests/ErrorsTests.swift
@@ -17,7 +17,7 @@ class ErrorTests: XCTestCase {
 
   func testItPrintsFlagNotFoundMessage() {
     let e = CommandErrors.flagNotFound("debug").errorMessage(forCommand: git)
-    XCTAssertEqual(e, "Error: unknown shorthand flag: \'debug\'\nUsage:\n  git [flags]\n  git [command]\n\nAvailable Commands:\n  rebase    \n  remote    \n\nFlags:\n  -d, --debug bool    (default true)\n  -r, --root int      (default 1)\n  -t, --togge bool    (default false)\n  -v, --verbose bool  (default false)\n\nUse \"git [command] --help\" for more information about a command.\n\nunknown shorthand flag: \'debug\'\nexit status 255")
+    XCTAssertEqual(e, "Error: unknown shorthand flag: \'debug\'\nUsage:\n  git [flags]\n  git [command]\n\nAvailable Commands:\n  rebase    \n  remote    \n\nFlags:\n  -d, --debug     \n  -r, --root int  (default 1)\n  -t, --togge     \n  -v, --verbose   \n\nUse \"git [command] --help\" for more information about a command.\n\nunknown shorthand flag: \'debug\'\nexit status 255")
   }
 
   func testItPrintsFlagNotFoundError() {
@@ -27,7 +27,7 @@ class ErrorTests: XCTestCase {
 
   func testItPrintsIncorrectFlagValueFoundErrorMessage() {
     let e = CommandErrors.incorrectFlagValue("debug", "Error when converting x to int").errorMessage(forCommand: git)
-    XCTAssertEqual(e, "Error: wrong flag value passed for flag: \'debug\' Error when converting x to int\nUsage:\n  git [flags]\n  git [command]\n\nAvailable Commands:\n  rebase    \n  remote    \n\nFlags:\n  -d, --debug bool    (default true)\n  -r, --root int      (default 1)\n  -t, --togge bool    (default false)\n  -v, --verbose bool  (default false)\n\nUse \"git [command] --help\" for more information about a command.\n\nwrong flag value passed for flag: \'debug\' Error when converting x to int\nexit status 255")
+    XCTAssertEqual(e, "Error: wrong flag value passed for flag: \'debug\' Error when converting x to int\nUsage:\n  git [flags]\n  git [command]\n\nAvailable Commands:\n  rebase    \n  remote    \n\nFlags:\n  -d, --debug     \n  -r, --root int  (default 1)\n  -t, --togge     \n  -v, --verbose   \n\nUse \"git [command] --help\" for more information about a command.\n\nwrong flag value passed for flag: \'debug\' Error when converting x to int\nexit status 255")
   }
 
   func testItPrintsIncorrectFlagValueFoundErrorError() {

--- a/Tests/GuakaTests/FlagSetTests.swift
+++ b/Tests/GuakaTests/FlagSetTests.swift
@@ -143,7 +143,7 @@ class FlagSetTests: XCTestCase {
         Flag(longName: "bla", value: 1),
         Flag(longName: "test", value: "")
       ]
-    ).flagSetAppeningHelp()
+    ).flagSetAppendingHelp()
 
     XCTAssertNotNil(fs.flags["h"])
     XCTAssertNotNil(fs.flags["help"])

--- a/Tests/GuakaTests/FlagTests.swift
+++ b/Tests/GuakaTests/FlagTests.swift
@@ -41,7 +41,7 @@ class FlagTests: XCTestCase {
     XCTAssertEqual(f1.flagPrintableDescription, "Here is a desc (default 1)")
 
     let f2 = Flag(longName: "debug", shortName: "d", value: true, description: "Here is a desc")
-    XCTAssertEqual(f2.flagPrintableDescription, "Here is a desc (default true)")
+    XCTAssertEqual(f2.flagPrintableDescription, "Here is a desc ")
 
     let f3 = Flag(longName: "debug", shortName: "d", value: "hello")
     XCTAssertEqual(f3.flagPrintableDescription, "(default hello)")
@@ -56,9 +56,9 @@ class FlagTests: XCTestCase {
         ]
     )
 
-    let description = fs.localDescription(withLocalFlags: Array(fs.flags.values))
+    let description = fs.localFlagDescription(withLocalFlags: Array(fs.flags.values))
     XCTAssertEqual(description
-      , "  -d, --debug bool     Here is a desc (default true)\n  -d, --toggle string  (default )\n      --verbose int    Here is a desc (default 1)")
+      , "  -d, --debug          Here is a desc \n  -d, --toggle string  (default )\n      --verbose int    Here is a desc (default 1)")
   }
 
   func testItCanPrintAFlagTable2ForLocalFlags() {
@@ -70,9 +70,9 @@ class FlagTests: XCTestCase {
         ]
     )
 
-    let description = fs.localDescription(withLocalFlags: Array(fs.flags.values))
+    let description = fs.localFlagDescription(withLocalFlags: Array(fs.flags.values))
     XCTAssertEqual(description
-      , "  -d, --debugxxxxxxxxxxx bool  Here is a desc (default true)\n      --verbose int            (default 1)\n  -d, --xxx string             Here is a desc (default 123)")
+      , "  -d, --debugxxxxxxxxxxx   Here is a desc \n      --verbose int        (default 1)\n  -d, --xxx string         Here is a desc (default 123)")
   }
 
   func testItCanPrintAFlagTableWithRequiredFlags() {
@@ -84,9 +84,9 @@ class FlagTests: XCTestCase {
         ]
     )
 
-    let description = fs.localDescription(withLocalFlags: Array(fs.flags.values))
+    let description = fs.localFlagDescription(withLocalFlags: Array(fs.flags.values))
     XCTAssertEqual(description
-      , "  -d, --debug bool   Here is a desc (default true)\n      --toggle int   (required)\n      --verbose int  Here is a desc (default 1)")
+      , "  -d, --debug        Here is a desc \n      --toggle int   (required)\n      --verbose int  Here is a desc (default 1)")
   }
 
   func testItCanPrintAFlagTable1ForGlobalFlags() {
@@ -98,9 +98,9 @@ class FlagTests: XCTestCase {
         ]
     )
 
-    let description = fs.globalDescription(withLocalFlags: [])
+    let description = fs.globalFlagsDescription(withLocalFlags: [])
     XCTAssertEqual(description
-      , "  -d, --debug bool     Here is a desc (default true)\n  -d, --toggle string  (default )\n      --verbose int    Here is a desc (default 1)")
+      , "  -d, --debug          Here is a desc \n  -d, --toggle string  (default )\n      --verbose int    Here is a desc (default 1)")
   }
 
   func testItCanPrintAFlagTable2ForGlobalFlags() {
@@ -112,9 +112,9 @@ class FlagTests: XCTestCase {
         ]
     )
 
-    let description = fs.globalDescription(withLocalFlags: [])
+    let description = fs.globalFlagsDescription(withLocalFlags: [])
     XCTAssertEqual(description
-      , "  -d, --debugxxxxxxxxxxx bool  Here is a desc (default true)\n      --verbose int            (default 1)\n  -d, --xxx string             Here is a desc (default 123)")
+      , "  -d, --debugxxxxxxxxxxx   Here is a desc \n      --verbose int        (default 1)\n  -d, --xxx string         Here is a desc (default 123)")
   }
 
 }

--- a/Tests/GuakaTests/HelpTests.swift
+++ b/Tests/GuakaTests/HelpTests.swift
@@ -60,35 +60,35 @@ class HelpTests: XCTestCase {
 
   func testItGenerateTheFlagsSection() {
     XCTAssertEqual(git.flagsSection.joined(separator: "\n"),
-                   "Flags:\n  -d, --debug bool    (default true)\n  -r, --root int      (default 1)\n  -t, --togge bool    (default false)\n  -v, --verbose bool  (default false)\n\n")
+                   "Flags:\n  -d, --debug     \n  -r, --root int  (default 1)\n  -t, --togge     \n  -v, --verbose   \n\n")
   }
 
   func testItGenerateTheFullHelp() {
     XCTAssertEqual(git.helpMessage,
-                   "Usage:\n  git [flags]\n  git [command]\n\nAvailable Commands:\n  rebase    \n  remote    \n\nFlags:\n  -d, --debug bool    (default true)\n  -r, --root int      (default 1)\n  -t, --togge bool    (default false)\n  -v, --verbose bool  (default false)\n\nUse \"git [command] --help\" for more information about a command.")
+                   "Usage:\n  git [flags]\n  git [command]\n\nAvailable Commands:\n  rebase    \n  remote    \n\nFlags:\n  -d, --debug     \n  -r, --root int  (default 1)\n  -t, --togge     \n  -v, --verbose   \n\nUse \"git [command] --help\" for more information about a command.")
 
     XCTAssertEqual(remote.helpMessage,
-                   "Usage:\n  git remote [flags]\n  git remote [command]\n\nAvailable Commands:\n  show    \n\nFlags:\n      --bar string   (default -)\n      --foo string   (default -)\n      --remote bool  (default true)\n      --xx bool      (default true)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"remote [command] --help\" for more information about a command.")
+                   "Usage:\n  git remote [flags]\n  git remote [command]\n\nAvailable Commands:\n  show    \n\nFlags:\n      --bar string  (default -)\n      --foo string  (default -)\n      --remote      \n      --xx          \n\nGlobal Flags:\n  -d, --debug     \n  -v, --verbose   \n\nUse \"remote [command] --help\" for more information about a command.")
 
     show.shortMessage = "Show short usage"
     XCTAssertEqual(show.helpMessage,
-                   "Show short usage\n\nUsage:\n  git remote show [flags]\n\nFlags:\n      --bar string  (default -)\n      --foo string  (default -)\n      --yy bool     (default true)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n      --remote bool   (default true)\n  -v, --verbose bool  (default false)\n\nUse \"show [command] --help\" for more information about a command.")
+                   "Show short usage\n\nUsage:\n  git remote show [flags]\n\nFlags:\n      --bar string  (default -)\n      --foo string  (default -)\n      --yy          \n\nGlobal Flags:\n  -d, --debug     \n      --remote    \n  -v, --verbose   \n\nUse \"show [command] --help\" for more information about a command.")
 
     XCTAssertEqual(rebase.helpMessage,
-                   "Usage:\n  git rebase [flags]\n\nFlags:\n  -v, --varvar bool  (default false)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"rebase [command] --help\" for more information about a command.")
+                   "Usage:\n  git rebase [flags]\n\nFlags:\n  -v, --varvar   \n\nGlobal Flags:\n  -d, --debug     \n  -v, --verbose   \n\nUse \"rebase [command] --help\" for more information about a command.")
   }
 
   func testItGenerateTheFullHelpEvenIfRequiredFlagsAreMissing() {
     git.add(flags: [Flag(longName: "hello", type: Int.self, required: true)])
     git.execute(commandLineArgs: expand("git -h"))
     XCTAssertEqual(git.helpMessage,
-                   "Usage:\n  git [flags]\n  git [command]\n\nAvailable Commands:\n  rebase    \n  remote    \n\nFlags:\n  -d, --debug bool    (default true)\n      --hello int     (required)\n  -r, --root int      (default 1)\n  -t, --togge bool    (default false)\n  -v, --verbose bool  (default false)\n\nUse \"git [command] --help\" for more information about a command.")
+                   "Usage:\n  git [flags]\n  git [command]\n\nAvailable Commands:\n  rebase    \n  remote    \n\nFlags:\n  -d, --debug      \n      --hello int  (required)\n  -r, --root int   (default 1)\n  -t, --togge      \n  -v, --verbose    \n\nUse \"git [command] --help\" for more information about a command.")
   }
 
   func testItPrintsHelpForAliases() {
     git.aliases = ["git1", "git2"]
     XCTAssertEqual(git.helpMessage,
-                   "Usage:\n  git [flags]\n  git [command]\n\nAliases:\n  git, git1, git2\n\nAvailable Commands:\n  rebase    \n  remote    \n\nFlags:\n  -d, --debug bool    (default true)\n  -r, --root int      (default 1)\n  -t, --togge bool    (default false)\n  -v, --verbose bool  (default false)\n\nUse \"git [command] --help\" for more information about a command.")
+                   "Usage:\n  git [flags]\n  git [command]\n\nAliases:\n  git, git1, git2\n\nAvailable Commands:\n  rebase    \n  remote    \n\nFlags:\n  -d, --debug     \n  -r, --root int  (default 1)\n  -t, --togge     \n  -v, --verbose   \n\nUse \"git [command] --help\" for more information about a command.")
   }
 
   func testItDoesNotShowDeprecatedCommands() {
@@ -100,32 +100,32 @@ class HelpTests: XCTestCase {
   func testItPrintsCommandDeprecatedOnTopOfDeprecatedCommand() {
     remote.deprecationStatus = .deprecated("Dont use this")
     XCTAssertEqual(remote.helpMessage,
-                   "Command \"remote\" is deprecated, Dont use this\nUsage:\n  git remote [flags]\n  git remote [command]\n\nAvailable Commands:\n  show    \n\nFlags:\n      --bar string   (default -)\n      --foo string   (default -)\n      --remote bool  (default true)\n      --xx bool      (default true)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"remote [command] --help\" for more information about a command.")
+                   "Command \"remote\" is deprecated, Dont use this\nUsage:\n  git remote [flags]\n  git remote [command]\n\nAvailable Commands:\n  show    \n\nFlags:\n      --bar string  (default -)\n      --foo string  (default -)\n      --remote      \n      --xx          \n\nGlobal Flags:\n  -d, --debug     \n  -v, --verbose   \n\nUse \"remote [command] --help\" for more information about a command.")
   }
 
   func testItFiltersOutDeprecatedFlags() {
     remote.flags[0].deprecatedStatus = .deprecated("Dont use this")
     XCTAssertEqual(remote.helpMessage,
-                   "Usage:\n  git remote [flags]\n  git remote [command]\n\nAvailable Commands:\n  show    \n\nFlags:\n      --bar string   (default -)\n      --remote bool  (default true)\n      --xx bool      (default true)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"remote [command] --help\" for more information about a command.")
+                   "Usage:\n  git remote [flags]\n  git remote [command]\n\nAvailable Commands:\n  show    \n\nFlags:\n      --bar string  (default -)\n      --remote      \n      --xx          \n\nGlobal Flags:\n  -d, --debug     \n  -v, --verbose   \n\nUse \"remote [command] --help\" for more information about a command.")
   }
 
   func testIfAllFlagsAreDeprecatedItDoesNotShowFlags() {
     rebase.flags[0].deprecatedStatus = .deprecated("Dont use this")
     XCTAssertEqual(rebase.helpMessage,
-                   "Usage:\n  git rebase [flags]\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"rebase [command] --help\" for more information about a command.")
+                   "Usage:\n  git rebase [flags]\n\nGlobal Flags:\n  -d, --debug     \n  -v, --verbose   \n\nUse \"rebase [command] --help\" for more information about a command.")
   }
 
   func testItPrintsTheExample() {
     rebase.example = "run git rebase blabla"
     XCTAssertEqual(rebase.helpMessage,
-                   "Usage:\n  git rebase [flags]\n\nExamples:\nrun git rebase blabla\n\nFlags:\n  -v, --varvar bool  (default false)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"rebase [command] --help\" for more information about a command.")
+                   "Usage:\n  git rebase [flags]\n\nExamples:\nrun git rebase blabla\n\nFlags:\n  -v, --varvar   \n\nGlobal Flags:\n  -d, --debug     \n  -v, --verbose   \n\nUse \"rebase [command] --help\" for more information about a command.")
   }
 
   func testItPrintsTheUsageSection() {
     rebase.usage = "rebase bla bla bla"
     XCTAssertEqual(rebase.name, "rebase")
     XCTAssertEqual(rebase.helpMessage,
-                   "Usage:\n  git rebase bla bla bla [flags]\n\nFlags:\n  -v, --varvar bool  (default false)\n\nGlobal Flags:\n  -d, --debug bool    (default true)\n  -v, --verbose bool  (default false)\n\nUse \"rebase [command] --help\" for more information about a command.")
+                   "Usage:\n  git rebase bla bla bla [flags]\n\nFlags:\n  -v, --varvar   \n\nGlobal Flags:\n  -d, --debug     \n  -v, --verbose   \n\nUse \"rebase [command] --help\" for more information about a command.")
   }
 
   func testItDoesNotPrintFlagsIfCommandHaveZeroFlags() {


### PR DESCRIPTION
Boolean flags dont have a description. This will change the help messages for flags from:

```swift
  -d, --debug bool  (default false)
```

to

```swift
  -d, --debug     
```

@goyox86 